### PR TITLE
Initial version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2.1
+jobs:
+  test:
+    parameters:
+        docker_image:
+          type: string
+          default: cimg/node:current
+    docker:
+      - image: << parameters.docker_image >>
+    steps:
+      - checkout
+      - run:
+          name: Setup
+          command: |
+            rm -rf node_modules package-lock.json
+            npm install
+      - run:
+          name: Running all unit tests
+          command: |
+            node -v
+            npm -v
+            npm run test
+
+workflows:
+  version: 2
+  test-all-node-versions:
+    jobs:
+      - test:
+          docker_image: cimg/node:14.21
+      - test:
+          docker_image: cimg/node:16.19
+      - test:
+          docker_image: cimg/node:18.9
+      - test:
+          docker_image: cimg/node:20.9
+      - test

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ilib-loctool-tap-i18n</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.wst.validation.validationbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
+	</natures>
+</projectDescription>

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ resource files.
 ## Configuration
 
 By default, plugin will localize source `.yml` and `.yaml` files,
-e.g. `/project/en.yml`,  and write localized files
-to a parallel file named for the locale: `/project/ru-RU.yml`.
+e.g. `/project/en.i18n.yml`,  and write localized files
+to a parallel file named for the locale: `/project/ru-RU.i18n.yml`.
 
 The plugin will look for the `tap` property within the `settings`
 of your `project.json` file. The following settings are
@@ -51,8 +51,7 @@ used within the yaml property:
       underscores to separate the locale parts instead of dashes.
       eg. "zh-Hans-CN" -> "zh_Hans_CN"
   - `commentPrefix` - a string that defines prefix for context comment for
-    translators. Only comments that start with the provided string will
-    be extracted and added to ResultSet, all other are ignored.
+    translators. The prefix will be stripped when comments are extracted.
 
 Example configuration:
 
@@ -61,11 +60,11 @@ Example configuration:
   "settings": {
     "tap": {
       "mappings": {
-        "**/source.yml": {
-          "template": "resources/[localeDir]/source.yaml"
+        "**/source.i18n.yml": {
+          "template": "resources/[localeDir]/source.i18n.yaml"
         },
-        "src/**/strings.yaml": {
-          "template": "[dir]/strings.[locale].yaml",
+        "src/**/en-US.i18n.yaml": {
+          "template": "[dir]/[locale].i18n.yaml",
           "commentPrefix": "L10N:"
         }
       }
@@ -74,10 +73,11 @@ Example configuration:
 }
 ```
 
-In the above example, any file named `source.yml` will be parsed.
-The output files are saved to the `resources` directory.
+In the above example, any file named `source.i18n.yml` will be parsed.
+The output files are saved to the `resources` directory under a directory
+named for the locale.
 
-Also files named `strings.yaml` that are located in directory `src`
+Also files named `en-US.i18n.yaml` that are located in directory `src`
 or any of its subdirectories will be parsed using the given `commentPrefix`
 rules.
 
@@ -92,16 +92,18 @@ It's also possible to use multiline comments.
 **Same line comments are ignored!**
 
 ```yaml
-header_text: "Header" #ignored comment
+header_text: "Header" # this comment is ignored
+
 # Comment for article_title.
 article_title: "Article:"
+
 # Comment for article_summary,
 # it includes view count and edit count values.
 article_summary: "Stats: {view_count} views, {edit_count} edits"
 ```
 
-Comments are trimmed upon extraction, therefore there's no
-difference between these two comments.
+Comments are trimmed upon extraction, so therefore there's no
+difference between these two example comments:
 
 ```yaml
 #comment
@@ -112,7 +114,7 @@ second: "second"
 
 Multiline comments will preserve line breaks as well as spaces
 on a new line (only space chars at the beginning of the
-first line and at the end of the last is trimmed):
+first line and at the end of the last are trimmed):
 
 ```yaml
 #    Multiline comment
@@ -122,7 +124,7 @@ would be parsed as
 `Multiline comment\n    with some extra spaces in between`
 
 Comments that start with the given `commentPrefix` in the mapping
-will be extracted, but the prefix will be stripped out first.
+will be extracted, but that prefix will be stripped out first.
 
 Example when the mapping says that the commentPrefix is "L10N:"
 
@@ -144,5 +146,3 @@ file for more details.
 ### v1.0.0
 
 - Initial version
-
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,148 @@
 # ilib-loctool-tap-i18n
-Loctool plugin to parse Tap-I18n style yaml files
+
+Ilib loctool plugin to parse and localize tap-i18n style of YAML
+resource files.
+
+## Configuration
+
+By default, plugin will localize source `.yml` and `.yaml` files,
+e.g. `/project/en.yml`,  and write localized files
+to a parallel file named for the locale: `/project/ru-RU.yml`.
+
+The plugin will look for the `tap` property within the `settings`
+of your `project.json` file. The following settings are
+used within the yaml property:
+
+- `mappings`: a mapping between file matchers and an object that gives
+  info used to localize the files that match it.
+  The matchers are
+  a [micromatch-style string](https://www.npmjs.com/package/micromatch),
+  similar to the the `includes` and `excludes` section of a
+  `project.json` file. The value of that mapping is an object that
+  can contain the following properties:
+  - `template`: a path template to use to generate the path to
+    the translated output files. The template replaces strings
+    in square brackets with special values, and keeps any characters
+    intact that are not in square brackets. The default template,
+    if not specified is "[dir[/[locale].yaml".
+    The plugin recognizes and replaces the following strings
+    in template strings:
+    - [dir] the original directory where the matched source file
+      came from. This is given as a directory that is relative
+      to the root of the project. eg. "foo/bar/strings.yaml" -> "foo/bar"
+    - [filename] the file name of the matching file.
+      eg. "foo/bar/strings.yaml" -> "strings.yaml"
+    - [basename] the basename of the matching file without any extension
+      eg. "foo/bar/strings.yaml" -> "strings"
+    - [extension] the extension part of the file name of the source file.
+      etc. "foo/bar/strings.yaml" -> "yaml"
+    - [locale] the full BCP-47 locale specification for the target locale
+      eg. "zh-Hans-CN" -> "zh-Hans-CN"
+    - [language] the language portion of the full locale
+      eg. "zh-Hans-CN" -> "zh"
+    - [script] the script portion of the full locale
+      eg. "zh-Hans-CN" -> "Hans"
+    - [region] the region portion of the full locale
+      eg. "zh-Hans-CN" -> "CN"
+    - [localeDir] the full locale where each portion of the locale
+      is a directory in this order: [langage], [script], [region].
+      eg, "zh-Hans-CN" -> "zh/Hans/CN", but "en" -> "en".
+    - [localeUnder] the full BCP-47 locale specification, but using
+      underscores to separate the locale parts instead of dashes.
+      eg. "zh-Hans-CN" -> "zh_Hans_CN"
+  - `commentPrefix` - a string that defines prefix for context comment for
+    translators. Only comments that start with the provided string will
+    be extracted and added to ResultSet, all other are ignored.
+
+Example configuration:
+
+```json
+{
+  "settings": {
+    "tap": {
+      "mappings": {
+        "**/source.yml": {
+          "template": "resources/[localeDir]/source.yaml"
+        },
+        "src/**/strings.yaml": {
+          "template": "[dir]/strings.[locale].yaml",
+          "commentPrefix": "L10N:"
+        }
+      }
+    }
+  }
+}
+```
+
+In the above example, any file named `source.yml` will be parsed.
+The output files are saved to the `resources` directory.
+
+Also files named `strings.yaml` that are located in directory `src`
+or any of its subdirectories will be parsed using the given `commentPrefix`
+rules.
+
+## Providing context comments
+
+The plugin automatically parses yaml comments and assigns them
+to corresponding strings as context comments.
+
+A context comment must be placed above the source string.
+It's also possible to use multiline comments.
+
+**Same line comments are ignored!**
+
+```yaml
+header_text: "Header" #ignored comment
+# Comment for article_title.
+article_title: "Article:"
+# Comment for article_summary,
+# it includes view count and edit count values.
+article_summary: "Stats: {view_count} views, {edit_count} edits"
+```
+
+Comments are trimmed upon extraction, therefore there's no
+difference between these two comments.
+
+```yaml
+#comment
+first: "first"
+#     comment <some extra space chars here>
+second: "second"
+```
+
+Multiline comments will preserve line breaks as well as spaces
+on a new line (only space chars at the beginning of the
+first line and at the end of the last is trimmed):
+
+```yaml
+#    Multiline comment
+#    with some extra spaces in between <some extra space chars here>
+```
+would be parsed as
+`Multiline comment\n    with some extra spaces in between`
+
+Comments that start with the given `commentPrefix` in the mapping
+will be extracted, but the prefix will be stripped out first.
+
+Example when the mapping says that the commentPrefix is "L10N:"
+
+```yaml
+# L10N: a prefixed comment
+foo: bar
+```
+
+This will extract the `foo` string with the value `bar` and the comment will
+be set to `a prefixed comment`.
+
+## License
+
+This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+file for more details.
+
+## Release Notes
+
+### v1.0.0
+
+- Initial version
+
+

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -22,7 +22,7 @@ var path = require("path");
 var Yaml = require("ilib-yaml");
 var Locale = require("ilib/lib/Locale.js");
 var tools = require("ilib-tools-common");
-const TranslationSet = require("loctool/lib/TranslationSet");
+var TranslationSet = require("loctool/lib/TranslationSet");
 
 var ResourceString = tools.ResourceString;
 var ResourcePlural = tools.ResourcePlural;

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -517,21 +517,6 @@ YamlFile.prototype.localizeText = function(translations, locale) {
 YamlFile.prototype.localize = function(translations, locales) {
     for (var i = 0; i < locales.length; i++) {
         var p, pathName = this.getLocalizedPath(locales[i]);
-        this.logger.debug("Checking for existing output file " + pathName);
-
-        try {
-            p = path.join(this.project.root, pathName);
-            if (fs.existsSync(p)) {
-                var data = fs.readFileSync(p, "utf8");
-                if (data) {
-                    this.parseOutputFile(data);
-                }
-            }
-        } catch (e) {
-            this.logger.warn("Could not read file: " + p);
-            this.logger.warn(e);
-        }
-
         this.logger.debug("Writing file " + pathName);
         p = path.join(this.project.target, pathName);
         var dir = path.dirname(p);

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -1,0 +1,521 @@
+/*
+ * YamlFile.js - represents a tap-i18n style yaml resource file for localization.
+ *
+ * Copyright © 2024 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require("fs");
+var path = require("path");
+var Yaml = require("ilib-yaml");
+var Locale = require("ilib/lib/Locale.js");
+var tools = require("ilib-tools-common");
+
+var ResourceString = tools.ResourceString;
+var ResourcePlural = tools.ResourcePlural;
+var TranslationSet = tools.TranslationSet;
+
+/**
+ * @class Represents a yaml source file.
+ * The props may contain any of the following properties:
+ *
+ * <ul>
+ * <li>project - the name of the project for this file
+ * <li>pathName - the path to the file, relative to the root of the project
+ * <li>type - type of this resource file
+ * <li>locale - the locale of this file
+ * <li>flavor - the flavor of this file (for customized strings)
+ * </ul>
+ * @param {Object} props properties that control the construction of this file.
+ */
+var YamlFile = function(props) {
+    if (props) {
+        this.project = props.project;
+        this.pathName = props.pathName;
+        this.locale = props.locale;
+        this.type = props.type;
+        this.flavor = props.flavor;
+    }
+
+    this.API = this.project.getAPI();
+    this.logger = this.API.getLogger("loctool.plugin.TapI18nYamlFile");
+
+    this.locale = this.locale || (this.project && this.project.sourceLocale) || "en-US";
+    this.mapping = this.type.getMapping(this.pathName);
+
+    if (this.pathName && this.project && this.project.flavorList) {
+        var filename = path.basename(this.pathName, ".yml");
+        var l = new Locale(filename);
+        if (l.getVariant() && this.project.flavorList.indexOf(l.getVariant()) > -1) {
+            this.flavor = l.getVariant();
+        }
+    }
+
+    this.yaml = new Yaml({
+        pathName: this.pathName,
+        project: this.project.getProjectId(),
+        locale: this.locale,
+        context: this.context,
+        datatype: this.type.getDataType(),
+        flavor: this.flavor,
+        commentPrefix: this.getCommentPrefix()
+    });
+
+    this.set = new TranslationSet(this.project.sourceLocale);
+};
+
+var pluralSuffices = {
+    "_plural_indefinite": "other",
+    "_plural_100": "other",
+    "_plural_11": "many",
+    "_plural_0": "zero",
+    "_plural_1": "one",
+    "_plural_2": "two",
+    "_plural_3": "few",
+    "_plural": "other",
+    "_zero": "zero",
+    "_one": "one",
+    "_two": "two",
+    "_few": "few",
+    "_many": "many",
+    "_other": "other",
+    "_100": "other",
+    "_11": "many",
+    "_0": "zero",
+    "_1": "one",
+    "_2": "two", 
+    "_3": "few"
+};
+
+/**
+ * Return whether or not the given resource represents one of
+ * the plural forms of a string in this set. If the resource's
+ * key has a recognized plural suffix, then the resource is a
+ * plural form and that suffix is returned. If the resource is
+ * the base form and other resources contain other plural forms,
+ * then this method returns an empty string to indicate that
+ * this is part of a plural, but it has no suffix. If the resource
+ * is not a plural form, then this method returns undefined.
+ * 
+ * @param {ResourceString} resource the resource to check
+ * @returns {string|undefined} the plural category string if
+ * this resource represents a plural form, or undefined if it
+ * does not.
+ */
+function isPluralForm(set, resource) {
+    // if this is a plural form, check for each suffix to see if
+    // it is there
+    var key = resource.getKey();
+    var suffices = Object.keys(pluralSuffices);
+    var suffix = suffices.find(function(suffix) {
+        return key.endsWith(suffix);
+    });
+    if (suffix) return suffix;
+
+    // if this is a base form, then check that some other plural
+    // form exists in the set. If it does, this is the string for
+    // the "one" (singular) plural category. If there is no other
+    // resources with the same base and one of the prefixes, then
+    // this is just a plain old string resource and we return
+    // undefined
+    suffix = suffices.find(function(suffix) {
+        var resources = set.getBy({
+            reskey: key + suffix
+        });
+        return resources.length ? resources[0] : false;
+    });
+    
+    return suffix ? "" : undefined;
+}
+
+/**
+ * Parse a yml file and store the resources found in it into the
+ * file's translation set.
+ *
+ * @param {String} str the string to parse
+ */
+YamlFile.prototype.parse = function(str) {
+    this.yaml.deserialize(str);
+    // now post-process the StringResource instances to find the plurals
+    // and convert them into PluralResource instances
+    var set = this.yaml.getTranslationSet();
+    var resources = set.getAll();
+    var pluralSet = new TranslationSet(this.project.sourceLocale);
+    var stringSet = new TranslationSet(this.project.sourceLocale);
+
+    // The strategy is to take every resource that was parsed from the
+    // yaml file and figure out whether or not it was part of a plural.
+    // If so, add the string to a plural resource that is added to
+    // the plural set, slowly building out all the plural categories
+    // together over multiple string resources. If it is not part of
+    // a plural, add it to the regular string/array set.
+    // Then, at the end of this method, add all of the
+    // plurals and strings together in a single set.
+    resources.forEach(function(resource) {
+        var key = resource.getKey();
+        // if this resource represents part of a plural form, then
+        // create a new plural or augment the existing plural
+        var suffix = isPluralForm(set, resource);
+        if (typeof(suffix) !== 'undefined') {
+            var category = pluralSuffices[suffix] ?? "one";
+            var basekey = suffix ? key.substring(0, key.length - suffix.length) : key;
+            var basePlural;
+            if (suffix) {
+                var basePluralArray = pluralSet.getBy({
+                    reskey: basekey
+                });
+                basePlural = basePluralArray && basePluralArray[0];
+            }
+            if (!basePlural) {
+                // no plural there yet, so create a new one
+                basePlural = new ResourcePlural({
+                    key: basekey,
+                    sourceLocale: resource.getSourceLocale(),
+                    project: resource.getProject(),
+                    pathName: resource.getPath(),
+                    datatype: resource.getDataType(),
+                    flavor: resource.getFlavor(),
+                    comment: resource.getComment(),
+                    index: resource.index,
+                    state: "new"
+                });
+                pluralSet.add(basePlural);
+            }
+
+            basePlural.addSourcePlural(category, resource.getSource());
+
+            var target = resource.getTarget();
+            if (target) {
+                basePlural.addTargetPlural(category, target);
+                basePlural.setTargetLocale(resource.getTargetLocale());
+            }
+        } else {
+            // this is just a simple string resource
+            stringSet.add(resource);
+        }
+    }.bind(this));
+
+    this.set.clear();
+    this.set.addAll(pluralSet.getAll());
+    this.set.addAll(stringSet.getAll());
+};
+
+/**
+ * Extract all of the resources from this file and keep them in
+ * memory.
+ */
+YamlFile.prototype.extract = function() {
+    this.logger.debug("Extracting strings from " + this.pathName);
+    if (this.pathName) {
+        var p = path.join(this.project.root, this.pathName);
+        try {
+            var data = fs.readFileSync(p, "utf8");
+            if (data) {
+                this.parse(data);
+            }
+        } catch (e) {
+            this.logger.warn("Could not read file: " + p);
+            this.logger.warn(e);
+        }
+    }
+};
+
+/**
+ * Get the path name of this resource file.
+ *
+ * @returns {String} the path name to this file
+ */
+YamlFile.prototype.getPath = function() {
+    return this.pathName;
+};
+
+/**
+ * Get the locale of this resource file.
+ *
+ * @returns {String} the locale spec of this file
+ */
+YamlFile.prototype.getLocale = function() {
+    return this.locale;
+};
+
+/**
+ * Get the locale of this resource file.
+ *
+ * @returns {String} the locale spec of this file
+ */
+YamlFile.prototype.getContext = function() {
+    return this.getContext();
+};
+
+/**
+ * Get the flavor of this resource file. The flavor determines
+ * the customization of the strings, which allows for different English
+ * source strings for the same resource key based on the flavor. For
+ * example, if your app has the string "Log-in" when there is no flavor,
+ * it might have the strings "Enter your partner ID:" for one partner,
+ * and "Enter your member number:" for a different partner. Each of the
+ * strings with a different flavor is a source string that needs to be
+ * translated separately, even though they have the same key.
+ *
+ * @returns {String|undefined} the flavor of this file, or undefined
+ * for no flavor
+ */
+YamlFile.prototype.getFlavor = function() {
+    return this.flavor;
+};
+
+
+/**
+ * Get all resources from this file. This will return all resources
+ * of mixed types (strings, arrays, or plurals).
+ *
+ * @returns {Resource} all of the resources available in this resource file.
+ */
+YamlFile.prototype.getAll = function() {
+    return this.set.getAll();
+};
+
+/**
+ * Add a resource to this file. The locale of the resource
+ * should correspond to the locale of the file, and the
+ * context of the resource should match the context of
+ * the file.
+ *
+ * @param {Resource} res a resource to add to this file
+ */
+YamlFile.prototype.addResource = function(res) {
+    this.set.add(res);
+};
+
+
+/**
+ * Add every resource in the given array to this file.
+ * @param {Array.<Resource>} resources an array of resources to add
+ * to this file
+ */
+YamlFile.prototype.addAll = function(resources) {
+    this.set.addAll(resources);
+};
+
+/**
+ * Generate the content of the resource file.
+ *
+ * @private
+ * @returns {String} the content of the resource file
+ */
+YamlFile.prototype.getContent = function() {
+    // Run through each resource and convert any plural resources
+    // into string resources so that they can be represented in
+    // the yaml file properly as tap-i18n expects it. All other
+    // types of resources are just left as-is.
+    var resources = this.set.getAll();
+    var filtered = new TranslationSet();
+
+    resources.forEach(function(resource) {
+        if (resource.getType() === "plural") {
+            var sourcePlurals = resource.getSource();
+            var targetPlurals = resource.getTarget();
+            var pluralCategories = Object.keys(sourcePlurals).sort();
+            pluralCategories.forEach(function(category) {
+                var newres = new ResourceString({
+                    key: resource.getKey() + "_" + category,
+                    sourceLocale: resource.getSourceLocale(),
+                    source: sourcePlurals[category],
+                    project: resource.getProject(),
+                    pathName: resource.getPath(),
+                    datatype: resource.getDataType(),
+                    flavor: resource.getFlavor(),
+                    comment: resource.getComment(),
+                    state: "new"
+                });
+                if (targetPlurals) {
+                    newres.setTarget(targetPlurals[category]);
+                    newres.setTargetLocale(resource.getTargetLocale());
+                }
+                filtered.add(newres);
+            });
+        } else {
+            filtered.add(resource);
+        }
+    }.bind(this));
+
+    var set = this.yaml.getTranslationSet();
+    set.clear();
+    set.addAll(filtered.getAll());
+
+    return this.yaml.serialize();
+};
+
+//we don't write to yaml source files
+YamlFile.prototype.write = function() {};
+
+/**
+ * Return the set of resources found in the current Android
+ * resource file.
+ *
+ * @returns {TranslationSet} The set of resources found in the
+ * current Java file.
+ */
+YamlFile.prototype.getTranslationSet = function() {
+    return this.set;
+}
+
+/**
+ * Return the location on disk where the version of this file localized
+ * for the given locale should be written. This should be relative to
+ * the root of the project.
+ *
+ * @param {String} locale the locale spec for the target locale
+ * @returns {String} the localized path name
+ */
+YamlFile.prototype.getLocalizedPath = function(locale) {
+    var mapping = this.mapping || this.type.getMapping(this.pathName) || this.type.getDefaultMapping();
+
+    return path.normalize(this.API.utils.formatPath(mapping.template, {
+        sourcepath: this.pathName,
+        locale: locale
+    }));
+};
+
+/**
+ * Localize the text of the current file to the given locale and return
+ * the results.
+ *
+ * @param {TranslationSet} translations the current set of translations
+ * @param {String} locale the locale to translate to
+ * @returns {String} the localized text of this file
+ */
+YamlFile.prototype.localizeText = function(translations, locale) {
+    var resources = this.set.getAll();
+
+    var translatedYaml = new Yaml({
+        pathName: this.pathName,
+        project: this.project.getProjectId(),
+        locale: locale,
+        context: this.context,
+        datatype: this.type.getDataType(),
+        flavor: this.flavor,
+        commentPrefix: this.getCommentPrefix()
+    });
+
+    resources.forEach(function(resource) {
+        var reskey = resource.getKey();
+        var source = resource.getSource();
+
+        var tester = new ResourceString({
+            resType: "string",
+            project: this.project.getProjectId(),
+            sourceLocale: this.project.getSourceLocale(),
+            reskey: reskey,
+            pathName: this.pathName,
+            datatype: this.type.datatype
+        });
+        var hashkey = tester.hashKeyForTranslation(locale); 
+        var translatedResource = translations.get(hashkey);
+        var translation;
+
+        if (locale === this.project.pseudoLocale && this.project.settings.nopseudo) {
+            translation = source;
+        } else if (!translatedResource && this.type && this.type.pseudos[locale]) {
+            var sourceTemp, sourceLocale = this.type.pseudos[locale].getPseudoSourceLocale();
+            if (sourceLocale !== this.project.sourceLocale) {
+                // translation is derived from a different locale's translation instead of from the source string
+                var sourceRes = translations.get(tester.hashKeyForTranslation(sourceLocale));
+                sourceTemp = sourceRes ? sourceRes.getTarget() : source;
+                translation = this.type.pseudos[locale].getString(sourceTemp);
+            } else {
+                translation = this.type.pseudos[locale].getString(source);
+            }
+        } else {
+            if (translatedResource && this.API.utils.cleanString(translatedResource.getSource()) === this.API.utils.cleanString(source)) {
+                this.logger.trace("Translation: " + translatedResource.getTarget());
+                translation = translatedResource.getTarget();
+            } else {
+                var note = translatedResource ? 'The source string has changed. Please update the translation to match if necessary. Previous source: "' + translatedResource.getSource() + '"' : undefined;
+                if (this.type) {
+                    this.type.newres.add(new ResourceString({
+                        project: this.project.getProjectId(),
+                        key: reskey,
+                        source: source,
+                        sourceLocale: this.project.sourceLocale,
+                        target: (translatedResource && translatedResource.getTarget()) || source,
+                        targetLocale: locale,
+                        pathName: this.pathName,
+                        datatype: this.type.datatype,
+                        state: "new",
+                        flavor: this.flavor,
+                        comment: note,
+                        index: this.resourceIndex++
+                    }));
+                }
+                this.logger.trace("Missing translation");
+                translation = this.type && this.type.missingPseudo && !this.project.settings.nopseudo ?
+                    this.type.missingPseudo.getString(source) : source;
+            }
+        }
+
+        tester.setTarget(translation);
+        tester.setTargetLocale(locale);
+
+        translatedYaml.addResource(tester);
+    }.bind(this));
+
+    return translatedYaml.serialize();
+};
+
+/**
+ * Localize the contents of this template file and write out the
+ * localized template file to a different file path.
+ *
+ * @param {TranslationSet} translations the current set of
+ * translations
+ * @param {Array.<String>} locales array of locales to translate to
+ */
+YamlFile.prototype.localize = function(translations, locales) {
+    for (var i = 0; i < locales.length; i++) {
+        var p, pathName = this.getLocalizedPath(locales[i]);
+        this.logger.debug("Checking for existing output file " + pathName);
+
+        try {
+            p = path.join(this.project.root, pathName);
+            if (fs.existsSync(p)) {
+                var data = fs.readFileSync(p, "utf8");
+                if (data) {
+                    this.parseOutputFile(data);
+                }
+            }
+        } catch (e) {
+            this.logger.warn("Could not read file: " + p);
+            this.logger.warn(e);
+        }
+
+        this.logger.debug("Writing file " + pathName);
+        p = path.join(this.project.target, pathName);
+        var dir = path.dirname(p);
+        this.API.utils.makeDirs(dir);
+        fs.writeFileSync(p, this.localizeText(translations, locales[i]), "utf-8");
+    }
+};
+
+/**
+ * Extract values of key 'commentPrefix' from the loaded schema
+ *
+ * @returns {String|undefined}
+ */
+YamlFile.prototype.getCommentPrefix = function() {
+    return this.mapping && this.mapping.commentPrefix;
+}
+
+module.exports = YamlFile;

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -78,6 +78,9 @@ var YamlFile = function(props) {
     this.set = new TranslationSet(this.project.sourceLocale);
 };
 
+// For documentation about the plural suffices, see the following:
+// https://github.com/TAPevents/tap-i18n?tab=readme-ov-file#the-_--helper (search for code examples 5 & 6)
+// https://i18next.github.io/i18next/pages/doc_features.html   (tap depends on i18next)
 var pluralSuffices = {
     "_plural_indefinite": "other",
     "_plural_100": "other",

--- a/YamlFile.js
+++ b/YamlFile.js
@@ -52,8 +52,8 @@ var YamlFile = function(props) {
 
     this.API = this.project.getAPI();
     this.logger = this.API.getLogger("loctool.plugin.TapI18nYamlFile");
-
-    this.locale = this.locale || (this.project && this.project.sourceLocale) || "en-US";
+    this.sourceLocale = (this.project && this.project.sourceLocale) || "en-US";
+    this.locale = this.locale || this.sourceLocale;
     this.mapping = this.type.getMapping(this.pathName);
 
     if (this.pathName && this.project && this.project.flavorList) {
@@ -67,6 +67,7 @@ var YamlFile = function(props) {
     this.yaml = new Yaml({
         pathName: this.pathName,
         project: this.project.getProjectId(),
+        sourceLocale: this.sourceLocale,
         locale: this.locale,
         context: this.context,
         datatype: this.type.getDataType(),

--- a/YamlFileType.js
+++ b/YamlFileType.js
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-var Locale = require("ilib/lib/Locale.js");
-var ResBundle = require("ilib/lib/ResBundle.js");
 var mm = require("micromatch");
 
 var YamlFile = require("./YamlFile.js");

--- a/YamlFileType.js
+++ b/YamlFileType.js
@@ -66,7 +66,7 @@ var YamlFileType = function(project) {
  * @type Object
  **/
 var defaultMappings = {
-    "**/*.y?(a)ml": {
+    "**/*.ya?ml": {
         template: "[dir]/[locale].[extension]"
     }
 };
@@ -94,7 +94,7 @@ YamlFileType.prototype.getMapping = function (pathName) {
  * @returns {Object}
  */
 YamlFileType.prototype.getDefaultMapping = function() {
-    return defaultMappings["**/*.y?(a)ml"];
+    return defaultMappings["**/*.ya?ml"];
 }
 
 /**

--- a/YamlFileType.js
+++ b/YamlFileType.js
@@ -1,0 +1,238 @@
+/*
+ * YamlFileType.js - manages a collection of tap-i18n style yaml files
+ *
+ * Copyright © 2024 Box, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Locale = require("ilib/lib/Locale.js");
+var ResBundle = require("ilib/lib/ResBundle.js");
+var mm = require("micromatch");
+
+var YamlFile = require("./YamlFile.js");
+
+/**
+ * @class Manage a collection of tap-i18n resource files.
+ *
+ * @param {Project} project that this type is in
+ */
+var YamlFileType = function(project) {
+    this.type = "tap-i18n";
+    this.datatype = "x-yaml";
+
+    this.resourceFiles = {};
+
+    this.project = project;
+    this.API = project.getAPI();
+    this.logger = this.API.getLogger("loctool.lib.TapI18nYamlFileType");
+
+    this.extensions = [ ".yml", ".yaml" ];
+
+    this.extracted = this.API.newTranslationSet(project.getSourceLocale());
+    this.newres = this.API.newTranslationSet(project.getSourceLocale());
+    this.pseudo = this.API.newTranslationSet(project.getSourceLocale());
+
+    this.pseudos = {};
+
+    // generate all the pseudo bundles we'll need
+    project.settings && project.settings.locales && project.settings.locales.forEach(function(locale) {
+        var pseudo = this.API.getPseudoBundle(locale, this, project);
+        if (pseudo) {
+            this.pseudos[locale] = pseudo;
+        }
+    }.bind(this));
+
+    // for use with missing strings
+    if (!project.settings.nopseudo) {
+        this.missingPseudo = this.API.getPseudoBundle(project.pseudoLocale, this, project);
+    }
+};
+
+/**
+ * Default mapping if none was provided in the yaml config.
+ *
+ * @type Object
+ **/
+var defaultMappings = {
+    "**/*.y?(a)ml": {
+        template: "[dir]/[locale].[extension]"
+    }
+};
+
+YamlFileType.prototype.getMapping = function (pathName) {
+    if (typeof(pathName) === "undefined") {
+        return undefined;
+    }
+
+    var yamlSettings = this.project.settings.tap;
+
+    var mappings = (yamlSettings && yamlSettings.mappings) ? yamlSettings.mappings : defaultMappings;
+    var patterns = Object.keys(mappings);
+
+    var match = patterns.find(function(pattern) {
+        return mm.isMatch(pathName, pattern);
+    });
+
+    return match && mappings[match];
+};
+
+/**
+ * Returns default mapping value.
+ *
+ * @returns {Object}
+ */
+YamlFileType.prototype.getDefaultMapping = function() {
+    return defaultMappings["**/*.y?(a)ml"];
+}
+
+/**
+ * Return true if this file type handles the type of file in the
+ * given path name.
+ * @param {String} pathName the path to check
+ * @returns true if this file type handles the given path name, and
+ * false otherwise
+ */
+YamlFileType.prototype.handles = function(pathName) {
+    this.logger.debug("YamlFileType handles " + pathName + "?");
+
+    var mapping = this.getMapping(pathName);
+
+    // No matching mapping exist => not localizable.
+    if (!mapping) {
+        return false;
+    }
+
+    // Check if this file is an already localized file.
+    var yamlSettings = this.project.settings.tap;
+    var mappings = (yamlSettings && yamlSettings.mappings) ? yamlSettings.mappings : defaultMappings;
+    var patterns = Object.keys(mappings);
+
+    // Check all mappings and see if filename matches mapping's template.
+    for (var i = 0; i < patterns.length; i++) {
+        var locale = this.API.utils.getLocaleFromPath(mappings[patterns[i]].template, pathName);
+
+        if (locale && locale !== this.project.sourceLocale) {
+            return false;
+        }
+    }
+
+    return true;
+};
+
+/**
+ * Write out all resources for this file type. For Android resources, each
+ * Android resource file is written out by itself. This method will
+ * iterate through all of the resource files it knows about and cause them
+ * each to write themselves out.
+ */
+YamlFileType.prototype.write = function() {
+    // yaml files are localized individually, so we don't have to
+    // write out the resources
+};
+
+YamlFileType.prototype.name = function() {
+    return "Tap Yaml File";
+};
+
+/**
+ * Return a new file of the current file type using the given
+ * path name.
+ *
+ * @param {String} pathName the path of the resource file
+ * @return {AndroidResourceFile} a resource file instance for the
+ * given path
+ */
+YamlFileType.prototype.newFile = function(pathName) {
+    return new YamlFile({
+        project: this.project,
+        pathName: pathName,
+        type: this
+    });
+};
+
+YamlFileType.prototype.getDataType = function() {
+    return this.datatype;
+};
+
+YamlFileType.prototype.getResourceTypes = function() {
+    return {};
+};
+
+/**
+ * Return the list of file name extensions that this plugin can
+ * process.
+ *
+ * @returns {Array.<string>} the list of file name extensions
+ */
+YamlFileType.prototype.getExtensions = function() {
+    return this.extensions;
+};
+
+/**
+ * Return the translation set containing all of the extracted
+ * resources for all instances of this type of file. This includes
+ * all new strings and all existing strings. If it was extracted
+ * from a source file, it should be returned here.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * extracted resources
+ */
+YamlFileType.prototype.getExtracted = function() {
+    return this.extracted;
+};
+
+/**
+ * Add the contents of the given translation set to the extracted resources
+ * for this file type.
+ *
+ * @param {TranslationSet} set set of resources to add to the current set
+ */
+YamlFileType.prototype.addSet = function(set) {
+    this.extracted.addSet(set);
+};
+
+/**
+ * Return the translation set containing all of the new
+ * resources for all instances of this type of file.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * new resources
+ */
+YamlFileType.prototype.getNew = function() {
+    return this.newres;
+};
+
+/**
+ * Return the translation set containing all of the pseudo
+ * localized resources for all instances of this type of file.
+ *
+ * @returns {TranslationSet} the set containing all of the
+ * pseudo localized resources
+ */
+YamlFileType.prototype.getPseudo = function() {
+    return this.pseudo;
+};
+
+/**
+ * Return the list of file name extensions that this plugin can
+ * process.
+ *
+ * @returns {Array.<string>} the list of file name extensions
+ */
+YamlFileType.prototype.getExtensions = function() {
+    return this.extensions;
+};
+
+module.exports = YamlFileType;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,70 @@
+{
+    "name": "ilib-loctool-tap-i18n",
+    "version": "1.0.0",
+    "main": "./YamlFileType.js",
+    "description": "A loctool plugin that knows how to process tap-i18n style yaml files",
+    "license": "Apache-2.0",
+    "keywords": [
+        "internationalization",
+        "i18n",
+        "localization",
+        "l10n",
+        "globalization",
+        "g11n",
+        "strings",
+        "resources",
+        "locale",
+        "translation",
+        "yaml"
+    ],
+    "email": "ehoogerbeets@gmail.com",
+    "author": {
+        "name": "Edwin Hoogerbeets",
+        "web": "http://www.translationcircle.com/",
+        "email": "ehoogerbeets@gmail.com"
+    },
+    "contributors": [
+        {
+            "name": "Edwin Hoogerbeets",
+            "email": "ehoogerbeets@gmail.com"
+        }
+    ],
+    "files": [
+        "README.md",
+        "LICENSE",
+        "YamlFile.js",
+        "YamlFileType.js"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/iLib-js/ilib-loctool-tap-i18n.git"
+    },
+    "scripts": {
+        "dist": "npm pack",
+        "test": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/.bin/jest --testEnvironment node",
+        "test:watch": "LANG=en_US.UTF8 node --experimental-vm-modules node_modules/.bin/jest --testEnvironment node --watch",
+        "debug": "node --experimental-vm-modules --inspect-brk node_modules/.bin/jest --testEnvironment node -i",
+        "clean": "git clean -f -d *",
+        "prepare": "conditional-install"
+    },
+    "engines": {
+        "node": ">=10.0"
+    },
+    "dependencies": {
+        "ilib-yaml": "file:../ilib-yaml/ilib-yaml-1.0.0.tgz",
+        "micromatch": "^4.0.5",
+        "yaml": "2.0.0"
+    },
+    "devDependencies": {
+        "conditional-install": "^1.0.1",
+        "loctool": "^2.23.1"
+    },
+    "conditionalDependencies": {
+        "process.versions.node < 14.0.0": {
+            "jest": "^26.0.0"
+        },
+        "process.versions.node >= 14.0.0": {
+            "jest": "^29.0.0"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -51,13 +51,13 @@
         "node": ">=10.0"
     },
     "dependencies": {
-        "ilib-yaml": "file:../ilib-yaml/ilib-yaml-1.0.0.tgz",
+        "ilib-yaml": "^1.0.0",
         "micromatch": "^4.0.5",
         "yaml": "2.0.0"
     },
     "devDependencies": {
         "conditional-install": "^1.0.1",
-        "loctool": "^2.24.0"
+        "loctool": "^2.24.1"
     },
     "conditionalDependencies": {
         "process.versions.node < 14.0.0": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     },
     "devDependencies": {
         "conditional-install": "^1.0.1",
-        "loctool": "^2.23.1"
+        "loctool": "^2.24.0"
     },
     "conditionalDependencies": {
         "process.versions.node < 14.0.0": {

--- a/test/YamlFile.test.js
+++ b/test/YamlFile.test.js
@@ -1246,7 +1246,7 @@ describe("yamlfile", function() {
 
     test("YamlFile localize text with arrays", function() {
         expect.assertions(7);
-debugger;
+
         var yml = new YamlFile({
             project: p,
             type: yft

--- a/test/YamlFile.test.js
+++ b/test/YamlFile.test.js
@@ -1,0 +1,1383 @@
+/*
+ * YamlFile.test.js - test the YamlFile object.
+ *
+ * Copyright © 2024 JEDLSoft
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var YamlFile = require("../YamlFile.js");
+var YamlFileType = require("../YamlFileType.js");
+var tools = require("ilib-tools-common");
+var CustomProject =  require("loctool/lib/CustomProject.js");
+
+var ResourceString = tools.ResourceString;
+var ResourcePlural = tools.ResourcePlural;
+var TranslationSet = tools.TranslationSet;
+
+var path = require("path");
+function diff(a, b) {
+    var min = Math.min(a.length, b.length);
+    for (var i = 0; i < min; i++) {
+        if (a[i] !== b[i]) {
+            console.log("Found difference at character " + i);
+            console.log("a: " + a.substring(i));
+            console.log("b: " + b.substring(i));
+            break;
+        }
+    }
+}
+var p = new CustomProject({
+    id: "webapp",
+    sourceLocale: "en-US",
+    resourceDirs: {
+        yml: "a/b"
+    },
+    plugins: [
+        path.join(process.cwd(), "YamlFileType")
+    ]
+}, "./test/testfiles", {
+    locales:["en-GB"],
+    nopseudo: true,
+    targetDir: "testfiles",
+    flavors: ["CHOCOLATE", "VANILLA"]
+});
+
+var yft = new YamlFileType(p);
+var projectWithMappings = new CustomProject({
+    id: "webapp",
+    sourceLocale: "en-US",
+    plugins: [
+        path.join(process.cwd(), "YamlFileType")
+    ]
+}, "./test/testfiles", {
+    locales:["en-GB"],
+    nopseudo: true,
+    targetDir: "testfiles",
+    tap: {
+        mappings: {
+            "**/source.yaml": {
+                template: "localized.[locale].yaml",
+                commentPrefix: "L10N:"
+            },
+            "**/test3.yml": {
+                template: "resources/[locale]/[filename]",
+                excludedKeys: ["c"],
+                commentPrefix: "L10N:"
+            },
+            "**/*.y?(a)ml": {
+                template: "resources/[locale]/[filename]"
+            }
+        }
+    }
+});
+
+var yamlFileTypeWithMappings = new YamlFileType(projectWithMappings);
+
+describe("yamlfile", function() {
+    test("YamlInit", function() {
+        p.init(function() {
+        });
+    });
+
+    test("YamlConstructorEmpty", function() {
+        expect.assertions(1);
+        var y = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(y).toBeTruthy();
+    });
+
+    test("YamlConstructorEmptyNoFlavor", function() {
+        expect.assertions(2);
+        var y = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(y).toBeTruthy();
+        expect(y.getFlavor()).toBeFalsy();
+    });
+
+    test("YamlConstructorFull", function() {
+        expect.assertions(2);
+        var y = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "x/y/en-US.yml"
+        });
+        expect(y).toBeTruthy();
+        expect(y.getPath()).toBe("x/y/en-US.yml");
+    });
+
+    test("YamlGetPath", function() {
+        expect.assertions(2);
+        var y = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "foo/bar/x.yml"
+        });
+        expect(y).toBeTruthy();
+        expect(y.getPath()).toBe("foo/bar/x.yml");
+    });
+
+    test("YamlWithFlavor", function() {
+        expect.assertions(2);
+        var y = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "foo/customized/en-US-VANILLA.yml"
+        });
+        expect(y).toBeTruthy();
+        expect(y.getFlavor()).toBe("VANILLA");
+    });
+
+    test("YamlWithNonFlavor", function() {
+        expect.assertions(2);
+        var y = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "foo/customized/en-US-PEACH.yml"
+        });
+        expect(y).toBeTruthy();
+        // PEACH is not a flavor in the project
+        expect(y.getFlavor()).toBeFalsy();
+    });
+
+    test("YamlFileParseSimpleGetByKey", function() {
+        expect.assertions(6);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'Jobs: Jobs\n' +
+                'Our_internship_program: Our internship program\n' +
+                '? Completing_an_internship_at_MyCompany_gives_you_the_opportunity_to_experience_innovation_and_personal_growth_at_one_of_the_best_companies_in_Silicon_Valley,_all_while_learning_directly_from_experienced,_successful_entrepreneurs.\n' +
+                ': Completing an internship at MyCompany gives you the opportunity to experience innovation\n' +
+                '  and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
+                '  directly from experienced, successful entrepreneurs.\n' +
+                'Working_at_MyCompany: Working at My Company, Inc.\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getBy({
+            reskey: "Jobs"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("Jobs");
+        expect(r[0].getKey()).toBe("Jobs");
+        expect(r[0].getComment()).toBeFalsy();
+    });
+
+    test("YamlFileParseWithSubkeys", function() {
+        expect.assertions(28);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+                '---\n' +
+                "'foo/bar/x.en-US.html.haml':\n" +
+                '  r9834724545: Jobs\n' +
+                '  r9483762220: Our internship program\n' +
+                '  r6782977423: |\n' +
+                '    Completing an internship at MyCompany gives you the opportunity to experience innovation\n' +
+                '    and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
+                '    directly from experienced, successful entrepreneurs.\n' +
+                "'foo/ssss/asdf.en-US.html.haml':\n" +
+                '  r4524523454: Working at MyCompany\n' +
+                '  r3254356823: Jobs\n' +
+                'foo:\n' +
+                '  bar:\n' +
+                '    asdf:\n' +
+                '      test: test of many levels\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(6);
+        expect(r[0].getSource()).toBe("Jobs");
+        expect(r[0].getSourceLocale()).toBe("en-US"); // source locale
+        expect(r[0].getKey()).toBe("foo/bar/x\\.en-US\\.html\\.haml.r9834724545");
+        expect(r[0].getContext()).toBeFalsy();
+        expect(r[1].getSource()).toBe("Our internship program");
+        expect(r[1].getSourceLocale()).toBe("en-US"); // source locale
+        expect(r[1].getKey()).toBe("foo/bar/x\\.en-US\\.html\\.haml.r9483762220");
+        expect(r[1].getContext()).toBeFalsy();
+        expect(r[2].getSource()).toBe('Completing an internship at MyCompany gives you the opportunity to experience innovation\n' +
+                'and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
+                'directly from experienced, successful entrepreneurs.\n');
+        expect(r[2].getSourceLocale()).toBe("en-US"); // source locale
+        expect(r[2].getKey()).toBe("foo/bar/x\\.en-US\\.html\\.haml.r6782977423");
+        expect(r[2].getContext()).toBeFalsy();
+        expect(r[3].getSource()).toBe("Working at MyCompany");
+        expect(r[3].getSourceLocale()).toBe("en-US"); // source locale
+        expect(r[3].getKey()).toBe("foo/ssss/asdf\\.en-US\\.html\\.haml.r4524523454");
+        expect(r[3].getContext()).toBeFalsy();
+        expect(r[4].getSource()).toBe("Jobs");
+        expect(r[4].getSourceLocale()).toBe("en-US"); // source locale
+        expect(r[4].getKey()).toBe("foo/ssss/asdf\\.en-US\\.html\\.haml.r3254356823");
+        expect(r[4].getContext()).toBeFalsy();
+        expect(r[5].getSource()).toBe("test of many levels");
+        expect(r[5].getSourceLocale()).toBe("en-US"); // source locale
+        expect(r[5].getKey()).toBe("foo.bar.asdf.test");
+        expect(r[5].getContext()).toBeFalsy();
+    });
+
+    test("YamlFileParseWithLocaleAndSubkeys", function() {
+        expect.assertions(22);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+                '---\n' +
+                "zh_Hans_CN:\n" +
+                "  foo/bar:\n" +
+                '    r9834724545: Jobs\n' +
+                '    r9483762220: Our internship program\n' +
+                '    r6782977423: |\n' +
+                '      Completing an internship at MyCompany gives you the opportunity to experience innovation\n' +
+                '      and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
+                '      directly from experienced, successful entrepreneurs.\n' +
+                "  foo/ssss:\n" +
+                '    r4524523454: Working at MyCompany\n' +
+                '    r3254356823: Jobs\n' +
+                '  foo:\n' +
+                '    bar:\n' +
+                '      asdf:\n' +
+                '        test: test of many levels\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(6);
+        // locale is not special for this type of yml file, so it should appear in the context
+        expect(r[0].getSource()).toBe("Jobs");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("zh_Hans_CN.foo/bar.r9834724545");
+        expect(r[1].getSource()).toBe("Our internship program");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("zh_Hans_CN.foo/bar.r9483762220");
+        expect(r[2].getSource()).toBe('Completing an internship at MyCompany gives you the opportunity to experience innovation\n' +
+                'and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
+                'directly from experienced, successful entrepreneurs.\n');
+        expect(r[2].getSourceLocale()).toBe("en-US");
+        expect(r[2].getKey()).toBe("zh_Hans_CN.foo/bar.r6782977423");
+        expect(r[3].getSource()).toBe("Working at MyCompany");
+        expect(r[3].getSourceLocale()).toBe("en-US");
+        expect(r[3].getKey()).toBe("zh_Hans_CN.foo/ssss.r4524523454");
+        expect(r[4].getSource()).toBe("Jobs");
+        expect(r[4].getSourceLocale()).toBe("en-US");
+        expect(r[4].getKey()).toBe("zh_Hans_CN.foo/ssss.r3254356823");
+        expect(r[5].getSource()).toBe("test of many levels");
+        expect(r[5].getSourceLocale()).toBe("en-US");
+        expect(r[5].getKey()).toBe("zh_Hans_CN.foo.bar.asdf.test");
+    });
+
+    test("YamlFileParseWithLocaleSubkeysAndPath", function() {
+        expect.assertions(23);
+        var yml = new YamlFile({
+            project: p,
+            pathName: "x/y/z/foo.yaml",
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+                '---\n' +
+                "  a:\n" +
+                '    r9834724545: Jobs\n' +
+                '    r9483762220: Our internship program\n' +
+                '    r6782977423: |\n' +
+                '      Completing an internship at MyCompany gives you the opportunity to experience innovation\n' +
+                '      and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
+                '      directly from experienced, successful entrepreneurs.\n' +
+                "  b:\n" +
+                '    r4524523454: Working at MyCompany\n' +
+                '    r3254356823: Jobs\n' +
+                '  foo:\n' +
+                '    bar:\n' +
+                '      asdf:\n' +
+                '        test: test of many levels\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(6);
+        // locale is not special for this type of yml file, so it should appear in the context
+        expect(r[0].getSource()).toBe("Jobs");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a.r9834724545");
+        expect(r[0].getContext()).toBeFalsy();
+        expect(r[1].getSource()).toBe("Our internship program");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("a.r9483762220");
+        expect(r[2].getSource()).toBe('Completing an internship at MyCompany gives you the opportunity to experience innovation\n' +
+                'and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
+                'directly from experienced, successful entrepreneurs.\n');
+        expect(r[2].getSourceLocale()).toBe("en-US");
+        expect(r[2].getKey()).toBe("a.r6782977423");
+        expect(r[3].getSource()).toBe("Working at MyCompany");
+        expect(r[3].getSourceLocale()).toBe("en-US");
+        expect(r[3].getKey()).toBe("b.r4524523454");
+        expect(r[4].getSource()).toBe("Jobs");
+        expect(r[4].getSourceLocale()).toBe("en-US");
+        expect(r[4].getKey()).toBe("b.r3254356823");
+        expect(r[5].getSource()).toBe("test of many levels");
+        expect(r[5].getSourceLocale()).toBe("en-US");
+        expect(r[5].getKey()).toBe("foo.bar.asdf.test");
+    });
+
+    test("YamlFileParseMultipleLevels", function() {
+        expect.assertions(25);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+            'duration:\n' +
+            '  top_header: Refine Your Query\n' +
+            '  header:\n' +
+            '    person: "George"\n' +
+            '    subaccount: "Admin" \n' +
+            '  variations:\n' +
+            '    person: "A %NAME% name?"\n' +
+            '    subaccount: "A %SUBACCOUNT_NAME%\'s name?"\n' +
+            '    asdf:\n' +
+            '      a: x y z\n' +
+            '      c: a b c\n'
+        );
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(7);
+        // locale is not special for this type of yml file, so it should appear in the context
+        expect(r[0].getSource()).toBe("Refine Your Query");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("duration.top_header");
+        expect(r[1].getSource()).toBe("George");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("duration.header.person");
+        expect(r[2].getSource()).toBe("Admin");
+        expect(r[2].getSourceLocale()).toBe("en-US");
+        expect(r[2].getKey()).toBe("duration.header.subaccount");
+        expect(r[3].getSource()).toBe("A %NAME% name?");
+        expect(r[3].getSourceLocale()).toBe("en-US");
+        expect(r[3].getKey()).toBe("duration.variations.person");
+        expect(r[4].getSource()).toBe('A %SUBACCOUNT_NAME%\'s name?');
+        expect(r[4].getSourceLocale()).toBe("en-US");
+        expect(r[4].getKey()).toBe("duration.variations.subaccount");
+        expect(r[5].getSource()).toBe("x y z");
+        expect(r[5].getSourceLocale()).toBe("en-US");
+        expect(r[5].getKey()).toBe("duration.variations.asdf.a");
+        expect(r[6].getSource()).toBe("a b c");
+        expect(r[6].getSourceLocale()).toBe("en-US");
+        expect(r[6].getKey()).toBe("duration.variations.asdf.c");
+    });
+
+    test("YamlFile parse plural forms simple", function() {
+        expect.assertions(8);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+debugger;
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'Jobs: Job\n' +
+                'Jobs_plural: Jobs\n' +
+                'file_count: There is {n} file in the folder.\n' +
+                'file_count_plural: There are {n} files in the folder.\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getBy({
+            reskey: "Jobs"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toStrictEqual({
+            "one": "Job",
+            "other": "Jobs"
+        });
+        expect(r[0].getKey()).toBe("Jobs");
+        r = set.getBy({
+            reskey: "file_count"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toStrictEqual({
+            "one": "There is {n} file in the folder.",
+            "other": "There are {n} files in the folder."
+        });
+        expect(r[0].getKey()).toBe("file_count");
+    });
+
+    test("YamlFile parse plural forms with CLDR plural forms", function() {
+        expect.assertions(8);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'Jobs_one: Job\n' +
+                'Jobs_other: Jobs\n' +
+                'file_count_one: There is {n} file in the folder.\n' +
+                'file_count_other: There are {n} files in the folder.\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getBy({
+            reskey: "Jobs"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toStrictEqual({
+            "one": "Job",
+            "other": "Jobs"
+        });
+        expect(r[0].getKey()).toBe("Jobs");
+        r = set.getBy({
+            reskey: "file_count"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toStrictEqual({
+            "one": "There is {n} file in the folder.",
+            "other": "There are {n} files in the folder."
+        });
+        expect(r[0].getKey()).toBe("file_count");
+    });
+
+    test("YamlFileParseSimpleRightSize", function() {
+        expect.assertions(4);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(0);
+        yml.parse(
+                'Working_at_MyCompany: Working at MyCompany\n' +
+                'Jobs: Jobs\n' +
+                'Our_internship_program: Our internship program\n' +
+                '? Completing_an_internship_at_MyCompany_gives_you_the_opportunity_to_experience_innovation_and_personal_growth_at_one_of_the_best_companies_in_Silicon_Valley,_all_while_learning_directly_from_experienced,_successful_entrepreneurs.\n' +
+                ': Completing an internship at MyCompany gives you the opportunity to experience innovation\n' +
+                '  and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
+                '  directly from experienced, successful entrepreneurs.\n');
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(4);
+    });
+
+    test("YamlFileParseComments", function() {
+        expect.assertions(19);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(0);
+        yml.parse('#first_a comment\n' +
+            'first_a:\n' +
+            '  #second_a comment\n' +
+            '  second_a: "second a"\n' +
+            '  #second_b comment\n' +
+            '  second_b: "second b"\n' +
+            '#first_b comment\n' +
+            'first_b:\n' +
+            '  #second_c comment\n' +
+            '  second_c:\n' +
+            '    third_a: "third a"\n' +
+            '    #third_b comment\n' +
+            '    third_b: "third b"\n' +
+            '  #   \n' +
+            '  second_d: "second d"\n');
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(5);
+        var r = set.getAll();
+        expect(r[0].getSource()).toBe("second a");
+        expect(r[0].getKey()).toBe("first_a.second_a");
+        expect(r[0].getComment()).toBe("second_a comment");
+        expect(r[1].getSource()).toBe("second b");
+        expect(r[1].getKey()).toBe("first_a.second_b");
+        expect(r[1].getComment()).toBe("second_b comment");
+        expect(r[2].getSource()).toBe("third a");
+        expect(r[2].getKey()).toBe("first_b.second_c.third_a");
+        expect(r[2].getComment()).toBe(undefined);
+        expect(r[3].getSource()).toBe("third b");
+        expect(r[3].getKey()).toBe("first_b.second_c.third_b");
+        expect(r[3].getComment()).toBe("third_b comment");
+        expect(r[4].getSource()).toBe("second d");
+        expect(r[4].getKey()).toBe("first_b.second_d");
+        expect(r[4].getComment()).toBe("");
+    });
+
+    test("YamlFileParseCommentTrim", function() {
+        expect.assertions(5);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('# space before\n' +
+            'first: "string"\n' +
+            '#space after \n' +
+            'second: "string"\n' +
+            '#   space both multiple        \n' +
+            'third: "string"');
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(3);
+        var r = set.getAll();
+        expect(r[0].getComment()).toBe("space before");
+        expect(r[1].getComment()).toBe("space after");
+        expect(r[2].getComment()).toBe("space both multiple");
+    });
+
+    test("YamlFileParseCommentMultiline", function() {
+        expect.assertions(5);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('first: "string"\n' +
+            '# this is multiline\n' +
+            '# comment    \n' +
+            'second: "string"\n' +
+            'third: "string"\n');
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(3);
+        var r = set.getAll();
+        expect(r[0].getComment()).toBe(undefined);
+        expect(r[1].getComment()).toBe("this is multiline\n comment");
+        expect(r[2].getComment()).toBe(undefined);
+    });
+
+    test("YamlFileParseArray", function() {
+        expect.assertions(8);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(0);
+        yml.parse(
+                '---\n' +
+                'Jobs:\n' +
+                '  - one and\n' +
+                '  - two and\n' +
+                '  - three\n' +
+                '  - four\n');
+        expect(set).toBeTruthy();
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(1);
+        expect(r[0].getKey()).toBe("Jobs");
+        expect(r[0].getSource()).toStrictEqual([
+            "one and",
+            "two and",
+            "three",
+            "four"
+        ]);
+    });
+
+    test("YamlParseArrayComments", function() {
+        expect.assertions(8);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(0);
+        yml.parse(
+            '---\n' +
+            '#first level comment\n' +
+            'Jobs:\n' +
+            '  - one and\n' +
+            '  #second level comment\n' +
+            '  - two and\n' +
+            '  - three\n' +
+            '  #second level comment\n' +
+            '  - four\n');
+        expect(set).toBeTruthy();
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r[0].getKey()).toBe("Jobs");
+        expect(r[0].getSource()).toStrictEqual([
+            "one and",
+            "two and",
+            "three",
+            "four"
+        ]);
+        expect(r[0].getComment()).toBe("first level comment");
+    });
+
+    test("YamlFileExtractFile", function() {
+        expect.assertions(14);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./test.yml"
+        });
+        expect(yml).toBeTruthy();
+        // should read the file
+        yml.extract();
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(10);
+        var r = set.getBy({
+            reskey: "Marketing"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("Marketing");
+        expect(r[0].getKey()).toBe("Marketing");
+        expect(r[0].getComment()).toBeFalsy();
+        var r = set.getBy({
+            reskey: "Everyone_at_MyCompany_has_not_only_welcomed_us_interns,_but_given_us_a_chance_to_ask_questions_and_really_learn_about_what_they_do\\._That's_why_I'm_thrilled_to_be_a_part_of_this_team_and_part_of_a_company_that_will,_I'm_sure,_soon_be_a_household_name\\."
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("Everyone at MyCompany has not only welcomed us interns, but given us a chance to ask questions and really learn about what they do. That's why I'm thrilled to be a part of this team and part of a company that will, I'm sure, soon be a household name.");
+        expect(r[0].getKey()).toBe("Everyone_at_MyCompany_has_not_only_welcomed_us_interns,_but_given_us_a_chance_to_ask_questions_and_really_learn_about_what_they_do\\._That's_why_I'm_thrilled_to_be_a_part_of_this_team_and_part_of_a_company_that_will,_I'm_sure,_soon_be_a_household_name\\.");
+        expect(r[0].getComment()).toBeFalsy();
+        var r = set.getBy({
+            reskey: "Learn_by_contributing_to_a_venture_that_will_change_the_world"
+        });
+        expect(r).toBeTruthy();
+        expect(r[0].getSource()).toBe("Learn by contributing to a venture that will change the world");
+        expect(r[0].getKey()).toBe("Learn_by_contributing_to_a_venture_that_will_change_the_world");
+        expect(r[0].getComment()).toBeFalsy();
+    });
+
+    test("YamlFileExtractUndefinedFile", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        // should attempt to read the file and not fail
+        yml.extract();
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(0);
+    });
+
+    test("YamlFileExtractBogusFile", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./objc/en.lproj/asdf.yml"
+        });
+        expect(yml).toBeTruthy();
+        // should attempt to read the file and not fail
+        yml.extract();
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(0);
+    });
+
+    test("YamlFileGetContent", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./asdf.yml",
+            locale: "de-DE"
+        });
+        expect(yml).toBeTruthy();
+        [
+            new ResourceString({
+                project: "webapp",
+                sourceLocale: "de-DE",
+                key: "source_text",
+                source: "Quellen\"text",
+                comment: "foo",
+                path: "asdf.yml",
+                context: "asdf.yml"
+            }),
+            new ResourceString({
+                project: "webapp",
+                sourceLocale: "de-DE",
+                key: "more_source_text",
+                source: "mehr Quellen\"text",
+                comment: "bar",
+                path: "asdf.yml",
+                context: "asdf.yml"
+            })
+        ].forEach(function(res) {
+            yml.addResource(res);
+        });
+        diff(yml.getContent(),
+            'more_source_text: mehr Quellen\"text\n' +
+            'source_text: Quellen\"text\n'
+        );
+        expect(yml.getContent()).toBe('more_source_text: mehr Quellen\"text\n' +
+            'source_text: Quellen\"text\n'
+        );
+    });
+
+    test("YamlFileGetContentComplicated", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./zh.yml",
+            locale: "zh-Hans-CN"
+        });
+        expect(yml).toBeTruthy();
+        [
+            new ResourceString({
+                project: "webapp",
+                sourceLocale: "zh-Hans-CN",
+                key: "• &amp;nbsp; Address a particular topic",
+                source: "• &amp;nbsp; 解决一个特定的主题",
+                comment: " ",
+                path: "zh.yml",
+                context: "zh.yml"
+            }),
+            new ResourceString({
+                project: "webapp",
+                sourceLocale: "zh-Hans-CN",
+                key: "&apos;&#41;, url&#40;imgs/masks/top_bar",
+                source: "&apos;&#41;, url&#40;imgs/masks/top_bar康生活相",
+                comment: "bar",
+                path: "zh.yml",
+                context: "zh.yml"
+            })
+        ].forEach(function(res) {
+            yml.addResource(res);
+        });
+        var expected =
+            '"&apos;&#41;, url&#40;imgs/masks/top_bar": "&apos;&#41;, url&#40;imgs/masks/top_bar康生活相"\n' +
+            '• &amp;nbsp; Address a particular topic: • &amp;nbsp; 解决一个特定的主题\n';
+        diff(yml.getContent(), expected);
+        expect(yml.getContent()).toBe(expected);
+    });
+
+    test("YamlFileGetContentWithNewlines", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./zh.yml",
+            locale: "zh-Hans-CN"
+        });
+        expect(yml).toBeTruthy();
+        [
+            new ResourceString({
+                project: "webapp",
+                sourceLocale: "zh-Hans-CN",
+                key: "short key",
+                source: "this is text that is relatively long and can run past the end of the page\nSo, we put a new line in the middle of it.",
+                comment: " ",
+                path: "zh.yml",
+                context: "zh.yml"
+            }),
+            new ResourceString({
+                project: "webapp",
+                sourceLocale: "zh-Hans-CN",
+                key: "A very long key that happens to have \n new line characters in the middle of it\\. Very very long\\. How long is it? It's so long that it won't even fit in 64 bits\\.",
+                source: "short text",
+                comment: "bar",
+                path: "zh.yml",
+                context: "zh.yml"
+            })
+        ].forEach(function(res) {
+            yml.addResource(res);
+        });
+        var expected =
+            "\"A very long key that happens to have \\n new line characters in the middle of it. Very very long. How long is it? It's so long that it won't even fit in 64 bits.\": short text\n" +
+            "short key: |-\n" +
+            "  this is text that is relatively long and can run past the end of the page\n" +
+            "  So, we put a new line in the middle of it.\n";
+        diff(yml.getContent(), expected);
+        expect(yml.getContent()).toBe(expected);
+    });
+
+    test("YamlFileGetContentWithSubkeys", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./zh.yml",
+            locale: "zh-Hans-CN"
+        });
+        expect(yml).toBeTruthy();
+        [
+            new ResourceString({
+                project: "webapp",
+                sourceLocale: "zh-Hans-CN",
+                key: "foo.bar.key1",
+                source: "medium length text that doesn't go beyond one line",
+                comment: " ",
+                path: "zh.yml"
+            }),
+            new ResourceString({
+                project: "webapp",
+                sourceLocale: "zh-Hans-CN",
+                key: "foo.bar.asdf.key2",
+                source: "short text",
+                comment: "bar",
+                path: "zh.yml"
+            })
+        ].forEach(function(res) {
+            yml.addResource(res);
+        });
+        var expected =
+            "foo:\n" +
+            "  bar:\n" +
+            "    asdf:\n" +
+            "      key2: short text\n" +
+            "    key1: medium length text that doesn't go beyond one line\n";
+        diff(yml.getContent(), expected);
+        expect(yml.getContent()).toBe(expected);
+    });
+
+    test("YamlFileGetContentEmpty", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./asdf.yml",
+            locale: "de-DE"
+        });
+        expect(yml).toBeTruthy();
+        expect(yml.getContent()).toBe('{}\n');
+    });
+
+    test("YamlFileRealContent", function() {
+        expect.assertions(5);
+
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./test.yml",
+            locale: "en-US"
+        });
+        expect(yml).toBeTruthy();
+        yml.extract();
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.get(ResourceString.hashKey("webapp", "en-US", "The_perks_of_interning", "x-yaml"));
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("The perks of interning");
+        expect(r.getKey()).toBe("The_perks_of_interning");
+    });
+
+    test("YamlFileRealContent2", function() {
+        expect.assertions(6);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./test2.yml",
+            locale: "en-US"
+        });
+        expect(yml).toBeTruthy();
+        yml.extract();
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.get(ResourceString.hashKey("webapp", "en-US", "saved_someone_else_time.subject", "x-yaml"));
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("Someone said a colleague’s answer to your question saved them a lot of time:");
+        expect(r.getKey()).toBe("saved_someone_else_time.subject");
+        expect(r.getSourceLocale()).toBe("en-US");
+    });
+
+    test("YamlFileAtInKeyName", function() {
+        expect.assertions(6);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./test2.yml",
+            locale: "en-US"
+        });
+        expect(yml).toBeTruthy();
+        yml.extract();
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.get(ResourceString.hashKey("webapp", "en-US", "member_question_asked@answered.email_subject", "x-yaml"));
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe("%1, %2 has answered a question you asked!");
+        expect(r.getKey()).toBe("member_question_asked@answered.email_subject");
+        expect(r.getSourceLocale()).toBe("en-US");
+    });
+
+    test("YamlFileRightResourceType", function() {
+        expect.assertions(4);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./test2.yml",
+            locale: "en-US"
+        });
+        expect(yml).toBeTruthy();
+        yml.extract();
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.get(ResourceString.hashKey("webapp", "en-US", "member_question_asked@answered.email_subject", "x-yaml"));
+        expect(r).toBeTruthy();
+        expect(r instanceof ResourceString).toBeTruthy();
+    });
+
+    test("YamlFileLocalizeText", function() {
+        expect.assertions(7);
+debugger;
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            locale: "en-US"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+            'thanked_note_time_saved:\n' +
+            '  email_subject: \'%1, you’re saving time!\'\n' +
+            '  subject: You’ve been thanked for saving a colleague\'s time!\n' +
+            '  body: “%1”\n' +
+            '  ctoa: View %1\n' +
+            '  push_data: You’ve saved lots of time! View %1\n' +
+            '  global_link: generic_link\n' +
+            '  setting_name: thanked_note_time_saved\n' +
+            '  daily_limit_exception_email: true\n'
+        );
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getBySource('%1, you’re saving time!');
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe('%1, you’re saving time!');
+        expect(r.getSourceLocale()).toBe('en-US');
+        expect(r.getKey()).toBe('thanked_note_time_saved.email_subject');
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'thanked_note_time_saved.email_subject',
+            source: '%1, you\'re saving time!',
+            target: '%1, vous économisez du temps!',
+            targetLocale: "fr-FR",
+            datatype: "x-yaml"
+        }));
+        var actual = yml.localizeText(translations, "fr-FR");
+        var expected =
+            'thanked_note_time_saved:\n' +
+            '  body: “%1”\n' +
+            '  ctoa: View %1\n' +
+            '  email_subject: "%1, vous économisez du temps!"\n' +
+            '  global_link: generic_link\n' +
+            '  push_data: You’ve saved lots of time! View %1\n' +
+            '  setting_name: thanked_note_time_saved\n' +
+            '  subject: You’ve been thanked for saving a colleague\'s time!\n';
+        diff(actual, expected);
+        expect(actual).toBe(expected);
+    });
+
+    test("YamlFileLocalizeTextMultiple", function() {
+        expect.assertions(12);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+            'thanked_note_time_saved:\n' +
+            '  email_subject: "%1, You\'re saving time!"\n' +
+            '  subject: "You’ve been thanked for saving a colleague\'s time!"\n' +
+            '  body: “%1”\n' +
+            '  ctoa: View %1\n' +
+            '  push_data: You\'ve saved time! View %1\n' +
+            '  global_link: generic_link\n' +
+            '  setting_name: thanked_note_time_saved\n' +
+            '  daily_limit_exception_email: true\n'
+        );
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getBySource('%1, You\'re saving time!');
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe('%1, You\'re saving time!');
+        expect(r.getKey()).toBe('thanked_note_time_saved.email_subject');
+        r = set.getBySource('You’ve been thanked for saving a colleague\'s time!');
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe('You’ve been thanked for saving a colleague\'s time!');
+        expect(r.getKey()).toBe('thanked_note_time_saved.subject');
+        r = set.getBySource('You\'ve saved time! View %1');
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe('You\'ve saved time! View %1');
+        expect(r.getKey()).toBe('thanked_note_time_saved.push_data');
+        var translations = new TranslationSet();
+        translations.addAll([
+            new ResourceString({
+                project: "webapp",
+                key: 'thanked_note_time_saved.email_subject',
+                source: '%1, You\'re saving time!',
+                target: '%1, vous économisez du temps!',
+                targetLocale: "fr-FR",
+                datatype: "x-yaml"
+            }),
+            new ResourceString({
+                project: "webapp",
+                key: 'thanked_note_time_saved.subject',
+                source: 'You’ve been thanked for saving a colleague\'s time!',
+                target: 'Vous avez été remercié pour économiser du temps!',
+                targetLocale: "fr-FR",
+                datatype: "x-yaml"
+            }),
+            new ResourceString({
+                project: "webapp",
+                key: 'thanked_note_time_saved.push_data',
+                source: 'You’ve saved time! View %1',
+                target: 'Vous avez économisé du temps! Voir %1',
+                targetLocale: "fr-FR",
+                datatype: "x-yaml"
+            }),
+        ]);
+        var actual = yml.localizeText(translations, "fr-FR");
+        var expected =
+            'thanked_note_time_saved:\n' +
+            '  body: “%1”\n' +
+            '  ctoa: View %1\n' +
+            '  email_subject: "%1, vous économisez du temps!"\n' +
+            '  global_link: generic_link\n' +
+            '  push_data: Vous avez économisé du temps! Voir %1\n' +
+            '  setting_name: thanked_note_time_saved\n' +
+            '  subject: Vous avez été remercié pour économiser du temps!\n';
+        diff(actual, expected);
+        expect(actual).toBe(expected);
+    });
+
+    test("YamlFileLocalizeTextWithPath", function() {
+        expect.assertions(7);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "x/y/z/foo.yaml",
+            locale: "en-US"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+            'thanked_note_time_saved:\n' +
+            '  email_subject: \'%1, you’re saving time!\'\n' +
+            '  subject: You’ve been thanked for saving a colleague\'s time!\n' +
+            '  body: “%1”\n' +
+            '  ctoa: View %1\n' +
+            '  push_data: You’ve saved lots of time! View %1\n' +
+            '  global_link: generic_link\n' +
+            '  setting_name: thanked_note_time_saved\n' +
+            '  daily_limit_exception_email: true\n'
+        );
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        var r = set.getBySource('%1, you’re saving time!');
+        expect(r).toBeTruthy();
+        expect(r.getSource()).toBe('%1, you’re saving time!');
+        expect(r.getSourceLocale()).toBe('en-US');
+        expect(r.getKey()).toBe('thanked_note_time_saved.email_subject');
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "webapp",
+            key: 'thanked_note_time_saved.email_subject',
+            source: '%1, you\'re saving time!',
+            target: '%1, vous économisez du temps!',
+            targetLocale: "fr-FR",
+            datatype: "x-yaml"
+        }));
+        var actual = yml.localizeText(translations, "fr-FR");
+        var expected =
+            'thanked_note_time_saved:\n' +
+            '  body: “%1”\n' +
+            '  ctoa: View %1\n' +
+            '  email_subject: "%1, vous économisez du temps!"\n' +
+            '  global_link: generic_link\n' +
+            '  push_data: You’ve saved lots of time! View %1\n' +
+            '  setting_name: thanked_note_time_saved\n' +
+            '  subject: You’ve been thanked for saving a colleague\'s time!\n';
+        diff(actual, expected);
+        expect(actual).toBe(expected);
+    });
+
+    test("YamlGetLocalizedPathDefault", function() {
+        expect.assertions(2);
+        var y = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./test2.yml"
+        });
+        expect(y).toBeTruthy();
+        y.extract();
+        expect(y.getLocalizedPath('de-DE')).toBe('de-DE.yml');
+    });
+
+    test("YamlFileGetContentPlural", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./asdf.yml",
+            locale: "de-DE"
+        });
+        expect(yml).toBeTruthy();
+        [
+            new ResourcePlural({
+                project: "webapp",
+                sourceLocale: "de-DE",
+                key: "asdf",
+                sourceStrings: {
+                    "one": "This is singular",
+                    "two": "This is double",
+                    "few": "This is a different case"
+                },
+                pathName: "a/b/c.java",
+                comment: "foobar foo",
+                state: "accepted"
+            })
+        ].forEach(function(res) {
+            yml.addResource(res);
+        });
+        var expected =
+            "asdf_few: This is a different case\n" +
+            "asdf_one: This is singular\n" +
+            "asdf_two: This is double\n";
+        diff(yml.getContent(),expected);
+        expect(yml.getContent()).toBe(expected);
+    });
+
+    test("YamlFileParseWithFlavor", function() {
+        expect.assertions(15);
+        var yml = new YamlFile({
+            project: p,
+            locale: "en-US",
+            type: yft,
+            flavor: "CHOCOLATE"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getSource()).toBe("foobar");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getContext()).toBeFalsy();
+        expect(r[0].getFlavor()).toBe("CHOCOLATE");
+        expect(r[1].getSource()).toBe("barfoo");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getContext()).toBeFalsy();
+        expect(r[1].getFlavor()).toBe("CHOCOLATE");
+    });
+
+    test("YamlFileParseWithNoFlavor", function() {
+        expect.assertions(15);
+        var yml = new YamlFile({
+            project: p,
+            locale: "en-US",
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getSource()).toBe("foobar");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getContext()).toBeFalsy();
+        expect(r[0].getFlavor()).toBeFalsy();
+        expect(r[1].getSource()).toBe("barfoo");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getContext()).toBeFalsy();
+        expect(r[1].getFlavor()).toBeFalsy();
+    });
+
+    test("YamlFileParseTargetWithNoFlavor", function() {
+        expect.assertions(17);
+        var yml = new YamlFile({
+            project: p,
+            locale: "es-US",
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getTarget()).toBe("foobar");
+        expect(r[0].getTargetLocale()).toBe("es-US");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getContext()).toBeFalsy();
+        expect(r[0].getFlavor()).toBeFalsy();
+        expect(r[1].getTarget()).toBe("barfoo");
+        expect(r[1].getTargetLocale()).toBe("es-US");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getContext()).toBeFalsy();
+        expect(r[1].getFlavor()).toBeFalsy();
+    });
+
+    test("YamlFileParseWithGleanedFlavor", function() {
+        expect.assertions(13);
+        var yml = new YamlFile({
+            project: p,
+            locale: "en-US",
+            type: yft,
+            pathName: "customization/en-CHOCOLATE.yml"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getSource()).toBe("foobar");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getFlavor()).toBe("CHOCOLATE");
+        expect(r[1].getSource()).toBe("barfoo");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getFlavor()).toBe("CHOCOLATE");
+    });
+
+    test("YamlFileParseWithNoGleanedFlavor", function() {
+        expect.assertions(15);
+        var yml = new YamlFile({
+            project: p,
+            locale: "en-ZA",
+            type: yft,
+            pathName: "customization/en-ZA.yml"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getTarget()).toBe("foobar");
+        expect(r[0].getTargetLocale()).toBe("en-ZA");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getFlavor()).toBeFalsy();
+        expect(r[1].getTarget()).toBe("barfoo");
+        expect(r[1].getTargetLocale()).toBe("en-ZA");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getFlavor()).toBeFalsy();
+    });
+});
+
+describe("yamlfile testsWithMapping", function() {
+    test("YamlGetCommentPrefix", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: projectWithMappings,
+            type: yamlFileTypeWithMappings,
+            pathName: "source.yaml"
+        });
+        expect(yml).toBeTruthy();
+        expect(yml.getCommentPrefix()).toBe("L10N:");
+    });
+
+    test("YamlGetCommentPrefixNotProvided", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: projectWithMappings,
+            type: yamlFileTypeWithMappings,
+            pathName: "random.yaml"
+        });
+        expect(yml).toBeTruthy();
+        expect(yml.getCommentPrefix()).toBe(undefined);
+    });
+
+    test("testYamlGetLocalizedPathFromMapping", function () {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: projectWithMappings,
+            type: yamlFileTypeWithMappings,
+            pathName: "source.yaml"
+        });
+        expect(yml).toBeTruthy();
+        expect(yml.getLocalizedPath('de-DE')).toBe('localized.de-DE.yaml');
+    });
+
+    test("YamlFileParsePrefixedComments", function() {
+        expect.assertions(5);
+        var yml = new YamlFile({
+            project: projectWithMappings,
+            type: yamlFileTypeWithMappings,
+            pathName: "source.yaml"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('#L10N: Prefixed comment\n' +
+            'first: "string"\n' +
+            '#  L10N:Prefixed comment with spaces before \n' +
+            'second: "string"\n' +
+            '# Not prefixed comment with L10N in it \n' +
+            'third: "string"');
+        var set = yml.getTranslationSet();
+        expect(set.size()).toBe(3);
+        var r = set.getAll();
+        expect(r[0].getComment()).toBe("Prefixed comment");
+        expect(r[1].getComment()).toBe("Prefixed comment with spaces before");
+        expect(r[2].getComment()).toBe("Not prefixed comment with L10N in it");
+    });
+
+    test("YamlFileExtractGetCommentPrefix", function() {
+        expect.assertions(7);
+        var yml = new YamlFile({
+            project: projectWithMappings,
+            type: yamlFileTypeWithMappings,
+            pathName: "test3.yml"
+        });
+        expect(yml).toBeTruthy();
+        expect(yml.getCommentPrefix()).toBe('L10N:');
+        yml.extract();
+        var set = yml.getTranslationSet();
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(3);
+        var r = set.getAll();
+        expect(r[0].getComment()).toBe('Comment with prefix');
+        expect(r[1].getComment()).toBe('Comment without prefix');
+        expect(r[2].getComment()).toBeUndefined();
+    });
+});

--- a/test/YamlFile.test.js
+++ b/test/YamlFile.test.js
@@ -24,6 +24,7 @@ var CustomProject =  require("loctool/lib/CustomProject.js");
 
 var ResourceString = tools.ResourceString;
 var ResourcePlural = tools.ResourcePlural;
+var ResourceArray = tools.ResourceArray;
 var TranslationSet = tools.TranslationSet;
 
 var path = require("path");
@@ -171,7 +172,7 @@ describe("yamlfile", function() {
                 '  and personal growth at one of the best companies in Silicon Valley, all while learning\n' +
                 '  directly from experienced, successful entrepreneurs.\n' +
                 'Working_at_MyCompany: Working at My Company, Inc.\n');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getBy({
             reskey: "Jobs"
@@ -205,7 +206,7 @@ describe("yamlfile", function() {
                 '  bar:\n' +
                 '    asdf:\n' +
                 '      test: test of many levels\n');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getAll();
         expect(r).toBeTruthy();
@@ -262,7 +263,7 @@ describe("yamlfile", function() {
                 '    bar:\n' +
                 '      asdf:\n' +
                 '        test: test of many levels\n');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getAll();
         expect(r).toBeTruthy();
@@ -314,7 +315,7 @@ describe("yamlfile", function() {
                 '    bar:\n' +
                 '      asdf:\n' +
                 '        test: test of many levels\n');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getAll();
         expect(r).toBeTruthy();
@@ -363,7 +364,7 @@ describe("yamlfile", function() {
             '      a: x y z\n' +
             '      c: a b c\n'
         );
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getAll();
         expect(r).toBeTruthy();
@@ -398,14 +399,14 @@ describe("yamlfile", function() {
             project: p,
             type: yft
         });
-debugger;
+
         expect(yml).toBeTruthy();
         yml.parse('---\n' +
                 'Jobs: Job\n' +
                 'Jobs_plural: Jobs\n' +
                 'file_count: There is {n} file in the folder.\n' +
                 'file_count_plural: There are {n} files in the folder.\n');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getBy({
             reskey: "Jobs"
@@ -440,7 +441,7 @@ debugger;
                 'Jobs_other: Jobs\n' +
                 'file_count_one: There is {n} file in the folder.\n' +
                 'file_count_other: There are {n} files in the folder.\n');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getBy({
             reskey: "Jobs"
@@ -469,7 +470,7 @@ debugger;
             type: yft
         });
         expect(yml).toBeTruthy();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(0);
         yml.parse(
                 'Working_at_MyCompany: Working at MyCompany\n' +
@@ -490,7 +491,7 @@ debugger;
             type: yft
         });
         expect(yml).toBeTruthy();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(0);
         yml.parse('#first_a comment\n' +
             'first_a:\n' +
@@ -540,7 +541,7 @@ debugger;
             'second: "string"\n' +
             '#   space both multiple        \n' +
             'third: "string"');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(3);
         var r = set.getAll();
         expect(r[0].getComment()).toBe("space before");
@@ -560,7 +561,7 @@ debugger;
             '# comment    \n' +
             'second: "string"\n' +
             'third: "string"\n');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(3);
         var r = set.getAll();
         expect(r[0].getComment()).toBe(undefined);
@@ -575,7 +576,7 @@ debugger;
             type: yft
         });
         expect(yml).toBeTruthy();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(0);
         yml.parse(
                 '---\n' +
@@ -585,7 +586,7 @@ debugger;
                 '  - three\n' +
                 '  - four\n');
         expect(set).toBeTruthy();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getAll();
         expect(r).toBeTruthy();
@@ -606,7 +607,7 @@ debugger;
             type: yft
         });
         expect(yml).toBeTruthy();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(0);
         yml.parse(
             '---\n' +
@@ -619,7 +620,7 @@ debugger;
             '  #second level comment\n' +
             '  - four\n');
         expect(set).toBeTruthy();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getAll();
         expect(r).toBeTruthy();
@@ -633,6 +634,154 @@ debugger;
         expect(r[0].getComment()).toBe("first level comment");
     });
 
+    test("YamlFileParseWithFlavor", function() {
+        expect.assertions(15);
+        var yml = new YamlFile({
+            project: p,
+            locale: "en-US",
+            type: yft,
+            flavor: "CHOCOLATE"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getSource()).toBe("foobar");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getContext()).toBeFalsy();
+        expect(r[0].getFlavor()).toBe("CHOCOLATE");
+        expect(r[1].getSource()).toBe("barfoo");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getContext()).toBeFalsy();
+        expect(r[1].getFlavor()).toBe("CHOCOLATE");
+    });
+
+    test("YamlFileParseWithNoFlavor", function() {
+        expect.assertions(15);
+        var yml = new YamlFile({
+            project: p,
+            locale: "en-US",
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getSource()).toBe("foobar");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getContext()).toBeFalsy();
+        expect(r[0].getFlavor()).toBeFalsy();
+        expect(r[1].getSource()).toBe("barfoo");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getContext()).toBeFalsy();
+        expect(r[1].getFlavor()).toBeFalsy();
+    });
+
+    test("YamlFileParseTargetWithNoFlavor", function() {
+        expect.assertions(17);
+        var yml = new YamlFile({
+            project: p,
+            locale: "es-US",
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getTarget()).toBe("foobar");
+        expect(r[0].getTargetLocale()).toBe("es-US");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getContext()).toBeFalsy();
+        expect(r[0].getFlavor()).toBeFalsy();
+        expect(r[1].getTarget()).toBe("barfoo");
+        expect(r[1].getTargetLocale()).toBe("es-US");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getContext()).toBeFalsy();
+        expect(r[1].getFlavor()).toBeFalsy();
+    });
+
+    test("YamlFileParseWithGleanedFlavor", function() {
+        expect.assertions(13);
+        var yml = new YamlFile({
+            project: p,
+            locale: "en-US",
+            type: yft,
+            pathName: "customization/en-CHOCOLATE.yml"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getSource()).toBe("foobar");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getFlavor()).toBe("CHOCOLATE");
+        expect(r[1].getSource()).toBe("barfoo");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getFlavor()).toBe("CHOCOLATE");
+    });
+
+    test("YamlFileParseWithNoGleanedFlavor", function() {
+        expect.assertions(15);
+        var yml = new YamlFile({
+            project: p,
+            locale: "en-ZA",
+            type: yft,
+            pathName: "customization/en-ZA.yml"
+        });
+        expect(yml).toBeTruthy();
+        yml.parse('---\n' +
+                'a: foobar\n' +
+                'b: barfoo\n');
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        expect(set.size()).toBe(2);
+        var r = set.getAll();
+        expect(r).toBeTruthy();
+        expect(r.length).toBe(2);
+        expect(r[0].getTarget()).toBe("foobar");
+        expect(r[0].getTargetLocale()).toBe("en-ZA");
+        expect(r[0].getSourceLocale()).toBe("en-US");
+        expect(r[0].getKey()).toBe("a");
+        expect(r[0].getFlavor()).toBeFalsy();
+        expect(r[1].getTarget()).toBe("barfoo");
+        expect(r[1].getTargetLocale()).toBe("en-ZA");
+        expect(r[1].getSourceLocale()).toBe("en-US");
+        expect(r[1].getKey()).toBe("b");
+        expect(r[1].getFlavor()).toBeFalsy();
+    });
+
     test("YamlFileExtractFile", function() {
         expect.assertions(14);
         var yml = new YamlFile({
@@ -643,7 +792,7 @@ debugger;
         expect(yml).toBeTruthy();
         // should read the file
         yml.extract();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(10);
         var r = set.getBy({
             reskey: "Marketing"
@@ -677,7 +826,7 @@ debugger;
         expect(yml).toBeTruthy();
         // should attempt to read the file and not fail
         yml.extract();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(0);
     });
 
@@ -691,7 +840,7 @@ debugger;
         expect(yml).toBeTruthy();
         // should attempt to read the file and not fail
         yml.extract();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(0);
     });
 
@@ -726,11 +875,11 @@ debugger;
         ].forEach(function(res) {
             yml.addResource(res);
         });
-        diff(yml.getContent(),
+        diff(yml.getContent(yml.getTranslationSet()),
             'more_source_text: mehr Quellen\"text\n' +
             'source_text: Quellen\"text\n'
         );
-        expect(yml.getContent()).toBe('more_source_text: mehr Quellen\"text\n' +
+        expect(yml.getContent(yml.getTranslationSet())).toBe('more_source_text: mehr Quellen\"text\n' +
             'source_text: Quellen\"text\n'
         );
     });
@@ -769,8 +918,8 @@ debugger;
         var expected =
             '"&apos;&#41;, url&#40;imgs/masks/top_bar": "&apos;&#41;, url&#40;imgs/masks/top_bar康生活相"\n' +
             '• &amp;nbsp; Address a particular topic: • &amp;nbsp; 解决一个特定的主题\n';
-        diff(yml.getContent(), expected);
-        expect(yml.getContent()).toBe(expected);
+        diff(yml.getContent(yml.getTranslationSet()), expected);
+        expect(yml.getContent(yml.getTranslationSet())).toBe(expected);
     });
 
     test("YamlFileGetContentWithNewlines", function() {
@@ -809,8 +958,8 @@ debugger;
             "short key: |-\n" +
             "  this is text that is relatively long and can run past the end of the page\n" +
             "  So, we put a new line in the middle of it.\n";
-        diff(yml.getContent(), expected);
-        expect(yml.getContent()).toBe(expected);
+        diff(yml.getContent(yml.getTranslationSet()), expected);
+        expect(yml.getContent(yml.getTranslationSet())).toBe(expected);
     });
 
     test("YamlFileGetContentWithSubkeys", function() {
@@ -848,8 +997,8 @@ debugger;
             "    asdf:\n" +
             "      key2: short text\n" +
             "    key1: medium length text that doesn't go beyond one line\n";
-        diff(yml.getContent(), expected);
-        expect(yml.getContent()).toBe(expected);
+        diff(yml.getContent(yml.getTranslationSet()), expected);
+        expect(yml.getContent(yml.getTranslationSet())).toBe(expected);
     });
 
     test("YamlFileGetContentEmpty", function() {
@@ -861,7 +1010,41 @@ debugger;
             locale: "de-DE"
         });
         expect(yml).toBeTruthy();
-        expect(yml.getContent()).toBe('{}\n');
+        expect(yml.getContent(yml.getTranslationSet())).toBe('{}\n');
+    });
+
+    test("YamlFileGetContentPlural", function() {
+        expect.assertions(2);
+        var yml = new YamlFile({
+            project: p,
+            type: yft,
+            pathName: "./asdf.yml",
+            locale: "de-DE"
+        });
+        expect(yml).toBeTruthy();
+        [
+            new ResourcePlural({
+                project: "webapp",
+                sourceLocale: "de-DE",
+                key: "asdf",
+                sourceStrings: {
+                    "one": "This is singular",
+                    "two": "This is double",
+                    "few": "This is a different case"
+                },
+                pathName: "a/b/c.java",
+                comment: "foobar foo",
+                state: "accepted"
+            })
+        ].forEach(function(res) {
+            yml.addResource(res);
+        });
+        var expected =
+            "asdf_few: This is a different case\n" +
+            "asdf_one: This is singular\n" +
+            "asdf_two: This is double\n";
+        diff(yml.getContent(yml.getTranslationSet()),expected);
+        expect(yml.getContent(yml.getTranslationSet())).toBe(expected);
     });
 
     test("YamlFileRealContent", function() {
@@ -875,7 +1058,7 @@ debugger;
         });
         expect(yml).toBeTruthy();
         yml.extract();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.get(ResourceString.hashKey("webapp", "en-US", "The_perks_of_interning", "x-yaml"));
         expect(r).toBeTruthy();
@@ -893,7 +1076,7 @@ debugger;
         });
         expect(yml).toBeTruthy();
         yml.extract();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.get(ResourceString.hashKey("webapp", "en-US", "saved_someone_else_time.subject", "x-yaml"));
         expect(r).toBeTruthy();
@@ -912,7 +1095,7 @@ debugger;
         });
         expect(yml).toBeTruthy();
         yml.extract();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.get(ResourceString.hashKey("webapp", "en-US", "member_question_asked@answered.email_subject", "x-yaml"));
         expect(r).toBeTruthy();
@@ -931,7 +1114,7 @@ debugger;
         });
         expect(yml).toBeTruthy();
         yml.extract();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.get(ResourceString.hashKey("webapp", "en-US", "member_question_asked@answered.email_subject", "x-yaml"));
         expect(r).toBeTruthy();
@@ -940,7 +1123,7 @@ debugger;
 
     test("YamlFileLocalizeText", function() {
         expect.assertions(7);
-debugger;
+
         var yml = new YamlFile({
             project: p,
             type: yft,
@@ -958,14 +1141,14 @@ debugger;
             '  setting_name: thanked_note_time_saved\n' +
             '  daily_limit_exception_email: true\n'
         );
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getBySource('%1, you’re saving time!');
         expect(r).toBeTruthy();
         expect(r.getSource()).toBe('%1, you’re saving time!');
         expect(r.getSourceLocale()).toBe('en-US');
         expect(r.getKey()).toBe('thanked_note_time_saved.email_subject');
-        var translations = new TranslationSet();
+        var translations = new TranslationSet("en-US");
         translations.add(new ResourceString({
             project: "webapp",
             key: 'thanked_note_time_saved.email_subject',
@@ -1006,7 +1189,7 @@ debugger;
             '  setting_name: thanked_note_time_saved\n' +
             '  daily_limit_exception_email: true\n'
         );
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getBySource('%1, You\'re saving time!');
         expect(r).toBeTruthy();
@@ -1020,7 +1203,7 @@ debugger;
         expect(r).toBeTruthy();
         expect(r.getSource()).toBe('You\'ve saved time! View %1');
         expect(r.getKey()).toBe('thanked_note_time_saved.push_data');
-        var translations = new TranslationSet();
+        var translations = new TranslationSet("en-US");
         translations.addAll([
             new ResourceString({
                 project: "webapp",
@@ -1061,6 +1244,226 @@ debugger;
         expect(actual).toBe(expected);
     });
 
+    test("YamlFile localize text with arrays", function() {
+        expect.assertions(7);
+debugger;
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+            'thanked_note_time_saved:\n' +
+            '  email_subject:\n' +
+            '    - "%1, You\'re saving time!"\n' +
+            '    - "You’ve been thanked for saving a colleague\'s time!"\n' +
+            '    - View %1\n'
+        );
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        var resources = set.getAll();
+        expect(resources.length).toBe(1);
+
+        var r = resources[0];
+        expect(r).toBeTruthy();
+        expect(r.getType()).toBe("array");
+
+        expect(r.getSource()).toStrictEqual([
+            '%1, You\'re saving time!',
+            'You’ve been thanked for saving a colleague\'s time!',
+            'View %1'
+        ]);
+
+        var translations = new TranslationSet("en-US");
+        translations.add(
+            new ResourceArray({
+                project: "webapp",
+                key: 'thanked_note_time_saved.email_subject',
+                source: [
+                    '%1, You\'re saving time!',
+                    'You’ve been thanked for saving a colleague\'s time!',
+                    'View %1'
+                ],
+                sourceLocale: "en-US",
+                target: [
+                    '%1, vous économisez du temps!',
+                    'Vous avez été remercié pour économiser du temps!',
+                    'Voir %1'
+                ],
+                targetLocale: "fr-FR",
+                datatype: "x-yaml"
+            })
+        );
+        var actual = yml.localizeText(translations, "fr-FR");
+        var expected =
+            'thanked_note_time_saved:\n' +
+            '  email_subject:\n' +
+            '    - "%1, vous économisez du temps!"\n' +
+            '    - Vous avez été remercié pour économiser du temps!\n' +
+            '    - Voir %1\n';
+        diff(actual, expected);
+        expect(actual).toBe(expected);
+    });
+
+    test("YamlFile localize text with plurals", function() {
+        expect.assertions(7);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+            'thanked_note_time_saved:\n' +
+            '  email_subject_one: There is {n} item.\n' +
+            '  email_subject_other: There are {n} items.\n'
+        );
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        var resources = set.getAll();
+        expect(resources.length).toBe(1);
+
+        var r = resources[0];
+        expect(r).toBeTruthy();
+        expect(r.getType()).toBe("plural");
+
+        expect(r.getSource()).toStrictEqual({
+            one: "There is {n} item.",
+            other: "There are {n} items."
+        });
+
+        var translations = new TranslationSet("en-US");
+        translations.add(
+            new ResourcePlural({
+                project: "webapp",
+                key: 'thanked_note_time_saved.email_subject',
+                source: {
+                    one: "There is {n} item.",
+                    other: "There are {n} items."
+                },
+                sourceLocale: "en-US",
+                target: {
+                    one: "Il y a {n} élément.",
+                    other: "Il y a {n} éléments."
+                },
+                targetLocale: "fr-FR",
+                datatype: "x-yaml"
+            })
+        );
+        var actual = yml.localizeText(translations, "fr-FR");
+        var expected =
+            'thanked_note_time_saved:\n' +
+            '  email_subject_one: Il y a {n} élément.\n' +
+            '  email_subject_other: Il y a {n} éléments.\n';
+        diff(actual, expected);
+        expect(actual).toBe(expected);
+    });
+
+    test("YamlFile localize text with plurals and adding a plural category", function() {
+        expect.assertions(7);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+            'thanked_note_time_saved:\n' +
+            '  email_subject_one: There is {n} item.\n' +
+            '  email_subject_other: There are {n} items.\n'
+        );
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        var resources = set.getAll();
+        expect(resources.length).toBe(1);
+
+        var r = resources[0];
+        expect(r).toBeTruthy();
+        expect(r.getType()).toBe("plural");
+
+        expect(r.getSource()).toStrictEqual({
+            one: "There is {n} item.",
+            other: "There are {n} items."
+        });
+
+        var translations = new TranslationSet("en-US");
+        translations.add(
+            new ResourcePlural({
+                project: "webapp",
+                key: 'thanked_note_time_saved.email_subject',
+                source: {
+                    one: "There is {n} item.",
+                    other: "There are {n} items."
+                },
+                sourceLocale: "en-US",
+                target: {
+                    one: "Jest {n} pozycja.",
+                    few: "Jest {n} pozycje.",
+                    other: "Jest {n} pozycji."
+                },
+                targetLocale: "pl-PL",
+                datatype: "x-yaml"
+            })
+        );
+        var actual = yml.localizeText(translations, "pl-PL");
+        var expected =
+            'thanked_note_time_saved:\n' +
+            '  email_subject_few: Jest {n} pozycje.\n' +
+            '  email_subject_one: Jest {n} pozycja.\n' +
+            '  email_subject_other: Jest {n} pozycji.\n';
+        diff(actual, expected);
+        expect(actual).toBe(expected);
+    });
+
+    test("YamlFile localize text with plurals and removing a plural category", function() {
+        expect.assertions(7);
+        var yml = new YamlFile({
+            project: p,
+            type: yft
+        });
+        expect(yml).toBeTruthy();
+        yml.parse(
+            'thanked_note_time_saved:\n' +
+            '  email_subject_one: There is {n} item.\n' +
+            '  email_subject_other: There are {n} items.\n'
+        );
+        var set = yml.getTranslationSet("en-US");
+        expect(set).toBeTruthy();
+        var resources = set.getAll();
+        expect(resources.length).toBe(1);
+
+        var r = resources[0];
+        expect(r).toBeTruthy();
+        expect(r.getType()).toBe("plural");
+
+        expect(r.getSource()).toStrictEqual({
+            one: "There is {n} item.",
+            other: "There are {n} items."
+        });
+
+        var translations = new TranslationSet("en-US");
+        translations.add(
+            new ResourcePlural({
+                project: "webapp",
+                key: 'thanked_note_time_saved.email_subject',
+                source: {
+                    one: "There is {n} item.",
+                    other: "There are {n} items."
+                },
+                sourceLocale: "en-US",
+                target: {
+                    other: "{n}件の商品があります。"
+                },
+                targetLocale: "ja-JP",
+                datatype: "x-yaml"
+            })
+        );
+        var actual = yml.localizeText(translations, "ja-JP");
+        var expected =
+            'thanked_note_time_saved:\n' +
+            '  email_subject_other: "{n}件の商品があります。"\n';
+        diff(actual, expected);
+        expect(actual).toBe(expected);
+    });
+
     test("YamlFileLocalizeTextWithPath", function() {
         expect.assertions(7);
         var yml = new YamlFile({
@@ -1081,14 +1484,14 @@ debugger;
             '  setting_name: thanked_note_time_saved\n' +
             '  daily_limit_exception_email: true\n'
         );
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         var r = set.getBySource('%1, you’re saving time!');
         expect(r).toBeTruthy();
         expect(r.getSource()).toBe('%1, you’re saving time!');
         expect(r.getSourceLocale()).toBe('en-US');
         expect(r.getKey()).toBe('thanked_note_time_saved.email_subject');
-        var translations = new TranslationSet();
+        var translations = new TranslationSet("en-US");
         translations.add(new ResourceString({
             project: "webapp",
             key: 'thanked_note_time_saved.email_subject',
@@ -1121,188 +1524,6 @@ debugger;
         expect(y).toBeTruthy();
         y.extract();
         expect(y.getLocalizedPath('de-DE')).toBe('de-DE.yml');
-    });
-
-    test("YamlFileGetContentPlural", function() {
-        expect.assertions(2);
-        var yml = new YamlFile({
-            project: p,
-            type: yft,
-            pathName: "./asdf.yml",
-            locale: "de-DE"
-        });
-        expect(yml).toBeTruthy();
-        [
-            new ResourcePlural({
-                project: "webapp",
-                sourceLocale: "de-DE",
-                key: "asdf",
-                sourceStrings: {
-                    "one": "This is singular",
-                    "two": "This is double",
-                    "few": "This is a different case"
-                },
-                pathName: "a/b/c.java",
-                comment: "foobar foo",
-                state: "accepted"
-            })
-        ].forEach(function(res) {
-            yml.addResource(res);
-        });
-        var expected =
-            "asdf_few: This is a different case\n" +
-            "asdf_one: This is singular\n" +
-            "asdf_two: This is double\n";
-        diff(yml.getContent(),expected);
-        expect(yml.getContent()).toBe(expected);
-    });
-
-    test("YamlFileParseWithFlavor", function() {
-        expect.assertions(15);
-        var yml = new YamlFile({
-            project: p,
-            locale: "en-US",
-            type: yft,
-            flavor: "CHOCOLATE"
-        });
-        expect(yml).toBeTruthy();
-        yml.parse('---\n' +
-                'a: foobar\n' +
-                'b: barfoo\n');
-        var set = yml.getTranslationSet();
-        expect(set).toBeTruthy();
-        expect(set.size()).toBe(2);
-        var r = set.getAll();
-        expect(r).toBeTruthy();
-        expect(r.length).toBe(2);
-        expect(r[0].getSource()).toBe("foobar");
-        expect(r[0].getSourceLocale()).toBe("en-US");
-        expect(r[0].getKey()).toBe("a");
-        expect(r[0].getContext()).toBeFalsy();
-        expect(r[0].getFlavor()).toBe("CHOCOLATE");
-        expect(r[1].getSource()).toBe("barfoo");
-        expect(r[1].getSourceLocale()).toBe("en-US");
-        expect(r[1].getKey()).toBe("b");
-        expect(r[1].getContext()).toBeFalsy();
-        expect(r[1].getFlavor()).toBe("CHOCOLATE");
-    });
-
-    test("YamlFileParseWithNoFlavor", function() {
-        expect.assertions(15);
-        var yml = new YamlFile({
-            project: p,
-            locale: "en-US",
-            type: yft
-        });
-        expect(yml).toBeTruthy();
-        yml.parse('---\n' +
-                'a: foobar\n' +
-                'b: barfoo\n');
-        var set = yml.getTranslationSet();
-        expect(set).toBeTruthy();
-        expect(set.size()).toBe(2);
-        var r = set.getAll();
-        expect(r).toBeTruthy();
-        expect(r.length).toBe(2);
-        expect(r[0].getSource()).toBe("foobar");
-        expect(r[0].getSourceLocale()).toBe("en-US");
-        expect(r[0].getKey()).toBe("a");
-        expect(r[0].getContext()).toBeFalsy();
-        expect(r[0].getFlavor()).toBeFalsy();
-        expect(r[1].getSource()).toBe("barfoo");
-        expect(r[1].getSourceLocale()).toBe("en-US");
-        expect(r[1].getKey()).toBe("b");
-        expect(r[1].getContext()).toBeFalsy();
-        expect(r[1].getFlavor()).toBeFalsy();
-    });
-
-    test("YamlFileParseTargetWithNoFlavor", function() {
-        expect.assertions(17);
-        var yml = new YamlFile({
-            project: p,
-            locale: "es-US",
-            type: yft
-        });
-        expect(yml).toBeTruthy();
-        yml.parse('---\n' +
-                'a: foobar\n' +
-                'b: barfoo\n');
-        var set = yml.getTranslationSet();
-        expect(set).toBeTruthy();
-        expect(set.size()).toBe(2);
-        var r = set.getAll();
-        expect(r).toBeTruthy();
-        expect(r.length).toBe(2);
-        expect(r[0].getTarget()).toBe("foobar");
-        expect(r[0].getTargetLocale()).toBe("es-US");
-        expect(r[0].getSourceLocale()).toBe("en-US");
-        expect(r[0].getKey()).toBe("a");
-        expect(r[0].getContext()).toBeFalsy();
-        expect(r[0].getFlavor()).toBeFalsy();
-        expect(r[1].getTarget()).toBe("barfoo");
-        expect(r[1].getTargetLocale()).toBe("es-US");
-        expect(r[1].getSourceLocale()).toBe("en-US");
-        expect(r[1].getKey()).toBe("b");
-        expect(r[1].getContext()).toBeFalsy();
-        expect(r[1].getFlavor()).toBeFalsy();
-    });
-
-    test("YamlFileParseWithGleanedFlavor", function() {
-        expect.assertions(13);
-        var yml = new YamlFile({
-            project: p,
-            locale: "en-US",
-            type: yft,
-            pathName: "customization/en-CHOCOLATE.yml"
-        });
-        expect(yml).toBeTruthy();
-        yml.parse('---\n' +
-                'a: foobar\n' +
-                'b: barfoo\n');
-        var set = yml.getTranslationSet();
-        expect(set).toBeTruthy();
-        expect(set.size()).toBe(2);
-        var r = set.getAll();
-        expect(r).toBeTruthy();
-        expect(r.length).toBe(2);
-        expect(r[0].getSource()).toBe("foobar");
-        expect(r[0].getSourceLocale()).toBe("en-US");
-        expect(r[0].getKey()).toBe("a");
-        expect(r[0].getFlavor()).toBe("CHOCOLATE");
-        expect(r[1].getSource()).toBe("barfoo");
-        expect(r[1].getSourceLocale()).toBe("en-US");
-        expect(r[1].getKey()).toBe("b");
-        expect(r[1].getFlavor()).toBe("CHOCOLATE");
-    });
-
-    test("YamlFileParseWithNoGleanedFlavor", function() {
-        expect.assertions(15);
-        var yml = new YamlFile({
-            project: p,
-            locale: "en-ZA",
-            type: yft,
-            pathName: "customization/en-ZA.yml"
-        });
-        expect(yml).toBeTruthy();
-        yml.parse('---\n' +
-                'a: foobar\n' +
-                'b: barfoo\n');
-        var set = yml.getTranslationSet();
-        expect(set).toBeTruthy();
-        expect(set.size()).toBe(2);
-        var r = set.getAll();
-        expect(r).toBeTruthy();
-        expect(r.length).toBe(2);
-        expect(r[0].getTarget()).toBe("foobar");
-        expect(r[0].getTargetLocale()).toBe("en-ZA");
-        expect(r[0].getSourceLocale()).toBe("en-US");
-        expect(r[0].getKey()).toBe("a");
-        expect(r[0].getFlavor()).toBeFalsy();
-        expect(r[1].getTarget()).toBe("barfoo");
-        expect(r[1].getTargetLocale()).toBe("en-ZA");
-        expect(r[1].getSourceLocale()).toBe("en-US");
-        expect(r[1].getKey()).toBe("b");
-        expect(r[1].getFlavor()).toBeFalsy();
     });
 });
 
@@ -1354,7 +1575,7 @@ describe("yamlfile testsWithMapping", function() {
             'second: "string"\n' +
             '# Not prefixed comment with L10N in it \n' +
             'third: "string"');
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set.size()).toBe(3);
         var r = set.getAll();
         expect(r[0].getComment()).toBe("Prefixed comment");
@@ -1372,12 +1593,24 @@ describe("yamlfile testsWithMapping", function() {
         expect(yml).toBeTruthy();
         expect(yml.getCommentPrefix()).toBe('L10N:');
         yml.extract();
-        var set = yml.getTranslationSet();
+        var set = yml.getTranslationSet("en-US");
         expect(set).toBeTruthy();
         expect(set.size()).toBe(3);
         var r = set.getAll();
         expect(r[0].getComment()).toBe('Comment with prefix');
         expect(r[1].getComment()).toBe('Comment without prefix');
         expect(r[2].getComment()).toBeUndefined();
+    });
+
+    test("Yaml GetLocalizedPath alternate", function() {
+        expect.assertions(2);
+
+        var y = new YamlFile({
+            project: projectWithMappings,
+            type: yamlFileTypeWithMappings,
+            pathName: "a/b/c/source.yaml"
+        });
+        expect(y).toBeTruthy();
+        expect(y.getLocalizedPath('de-DE')).toBe('localized.de-DE.yaml');
     });
 });

--- a/test/YamlFileType.test.js
+++ b/test/YamlFileType.test.js
@@ -1,0 +1,146 @@
+/*
+ * YamlFileType.test.js - test the HTML template file type handler object.
+ *
+ * Copyright © 2016-2017, 2023 2021- 2022-2023 HealthTap, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+if (!YamlFileType) {
+    var YamlFileType = require("../YamlFileType.js");
+    var CustomProject =  require("loctool/lib/CustomProject.js");
+}
+var path = require("path");
+
+var projectWithMappings = new CustomProject({
+    sourceLocale: "en-US",
+    plugins: [
+        path.join(process.cwd(), "YamlFileType")
+    ]
+}, "./test/testfiles", {
+    locales:["en-GB"],
+    tap: {
+        mappings: {
+            "foo.yml": {
+                template: "res/[locale]/foo.yml"
+            },
+            "**/*.y?(a)ml": {
+                template: "resources/[locale]/[filename]"
+            },
+            "**/strings.yaml": {
+                template: "[dir]/strings.[locale].yaml"
+            },
+            "**/test/strings.y?(a)ml": {
+                template: "[dir]/[basename]/[locale].[extension]"
+            }
+        }
+    }
+});
+
+var legacyProject = new CustomProject({
+    sourceLocale: "en-US",
+    resourceDirs: {
+        "yml": "config/locales"
+    },
+    plugins: [
+        path.join(process.cwd(), "YamlFileType")
+    ]
+}, "./test/testfiles", {
+    locales:["en-GB"]
+});
+
+var legacyProjectWithFlavor = new CustomProject({
+    sourceLocale: "en-US",
+    resourceDirs: {
+        "yml": "config/locales"
+    }
+}, "./test/testfiles", {
+    locales:["en-GB"],
+    flavors: ["ASDF"]
+});
+
+describe("yamlfiletype projectWithMappingsTests", function() {
+    test("YamlFileTypeConstructor", function() {
+        expect.assertions(1);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+    });
+
+    test("YamlFileTypeHandlesYml", function() {
+        expect.assertions(2);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("foo.yml")).toBeTruthy();
+    });
+
+    test("YamlFileTypeHandlesYaml", function() {
+        expect.assertions(2);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("foo.yaml")).toBeTruthy();
+    });
+
+    test("YamlFileTypeHandlesAnythingFalse", function() {
+        expect.assertions(4);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("foo.tmpl.html")).toBeFalsy();
+        expect(yft.handles("foo.html.haml")).toBeFalsy();
+        expect(yft.handles("foo.js")).toBeFalsy();
+    });
+
+    test("YamlFileTypeHandlesNoResourceFiles", function() {
+        expect.assertions(2);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("res/ru-RU/foo.yml")).toBeFalsy();
+    });
+
+    test("YamlFileTypeHandlesSourceLocaleFilesInSubfolders", function() {
+        expect.assertions(2);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("subfolder/strings.en-US.yaml")).toBeTruthy();
+    });
+
+    test("YamlFileTypeHandlesNoLocalizedFilesInSubfolders", function() {
+        expect.assertions(2);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("subfolder/strings.ru-RU.yaml")).toBeFalsy();
+    });
+
+    test("YamlFileTypeHandlesFilesNamedForALocale", function() {
+        expect.assertions(4);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("en-US.yml")).toBeTruthy();
+        expect(yft.handles("de-DE.yml")).toBeTruthy();
+        expect(yft.handles("en.yml")).toBeTruthy();
+    });
+
+    test("YamlFileTypeHandlesResourceFilesInSubdirs", function() {
+        expect.assertions(2);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("res/ru-RU/foo.yml")).toBeFalsy();
+    });
+
+    test("YamlFileTypeHandlesBasenameDirMapping", function() {
+        expect.assertions(3);
+        var yft = new YamlFileType(projectWithMappings);
+        expect(yft).toBeTruthy();
+        expect(yft.handles("test/strings.yaml")).toBeTruthy();
+        expect(yft.handles("test/strings/ru-RU.yaml")).toBeFalsy();
+    });
+});

--- a/test/testfiles/test.yml
+++ b/test/testfiles/test.yml
@@ -1,0 +1,19 @@
+---
+Jobs: Jobs
+Our_internship_program: Our internship program
+? Completing_an_internship_at_MyCompany_gives_you_the_opportunity_to_experience_innovation_and_personal_growth_at_one_of_the_best_companies_in_Silicon_Valley,_all_while_learning_directly_from_experienced,_successful_entrepreneurs.
+: Completing an internship at MyCompany gives you the opportunity to experience innovation
+  and personal growth at one of the best companies in Silicon Valley, all while learning
+  directly from experienced, successful entrepreneurs.
+The_perks_of_interning: The perks of interning
+Learn_by_contributing_to_a_venture_that_will_change_the_world: Learn by contributing
+  to a venture that will change the world
+Angela_Federovski,_Former_MyCompany_Intern: Angela Federovski, Former MyCompany Intern
+? Everyone_at_MyCompany_has_not_only_welcomed_us_interns,_but_given_us_a_chance_to_ask_questions_and_really_learn_about_what_they_do._That's_why_I'm_thrilled_to_be_a_part_of_this_team_and_part_of_a_company_that_will,_I'm_sure,_soon_be_a_household_name.
+: Everyone at MyCompany has not only welcomed us interns, but given us a chance to
+  ask questions and really learn about what they do. That's why I'm thrilled to be
+  a part of this team and part of a company that will, I'm sure, soon be a household
+  name.
+Apply_now!: Apply now!
+Join_us!: Join us!
+Marketing: Marketing

--- a/test/testfiles/test2.yml
+++ b/test/testfiles/test2.yml
@@ -1,0 +1,11 @@
+---
+saved_someone_else_time:
+  subject:      "Someone said a colleague’s answer to your question saved them a lot of time:"
+member_answer_thank_follow_up:
+  subject:      "Thank %1 for answering!"
+member_question_asked:
+  email_subject: "%1, %2 has answered a question you asked!"
+  category: "a"
+'member_question_asked@answered':
+  email_subject: "%1, %2 has answered a question you asked!"
+  

--- a/test/testfiles/test3.yml
+++ b/test/testfiles/test3.yml
@@ -1,0 +1,9 @@
+---
+title:
+  read_me:
+    #L10N: Comment with prefix
+    a: good
+  do_not_read_me:
+    # Comment without prefix
+    b: good too
+    c: bad


### PR DESCRIPTION
- reads/writes tap-i18n style yaml resource files
- uses the ilib-yaml library to parse/generate the files
- post-processes the resources after parsing and pre-processes the resources before generating to take care of tap-i18n style plurals
- this is a draft until ilib-tools-common and ilib-yaml are published to npm