### PR TITLE
fix: Respect Project's localeMap when generating localized file path

### DIFF
--- a/YamlFile.js
+++ b/YamlFile.js
@@ -395,6 +395,7 @@ YamlFile.prototype.getTranslationSet = function() {
  * @returns {String} the localized path name
  */
 YamlFile.prototype.getLocalizedPath = function(locale) {
+    locale = this.project.getOutputLocale(locale);
     var mapping = this.mapping || this.type.getMapping(this.pathName) || this.type.getDefaultMapping();
 
     return path.normalize(this.API.utils.formatPath(mapping.template, {

--- a/test/YamlFile.test.js
+++ b/test/YamlFile.test.js
@@ -64,6 +64,7 @@ var projectWithMappings = new CustomProject({
     ]
 }, "./test/testfiles", {
     locales:["en-GB"],
+    localeMap: {"es-419": "es-MX"},
     nopseudo: true,
     targetDir: "testfiles",
     tap: {
@@ -1612,5 +1613,17 @@ describe("yamlfile testsWithMapping", function() {
         });
         expect(y).toBeTruthy();
         expect(y.getLocalizedPath('de-DE')).toBe('localized.de-DE.yaml');
+    });
+
+    test("Yaml GetLocalizedPath localeMap", function() {
+        expect.assertions(2);
+
+        var y = new YamlFile({
+            project: projectWithMappings,
+            type: yamlFileTypeWithMappings,
+            pathName: "a/b/c/source.yaml"
+        });
+        expect(y).toBeTruthy();
+        expect(y.getLocalizedPath('es-419')).toBe('localized.es-MX.yaml');
     });
 });


### PR DESCRIPTION
Locale mapping set through `project.json` [`.settings.localeMap`] does not work with this plugin. Added missing mapping call (like https://github.com/iLib-js/loctool/blob/0cf36a8973628929a1c2185189cce652c901e8c5/lib/YamlFile.js#L515) to fix that.